### PR TITLE
Fix/elevation processing in rendering

### DIFF
--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
@@ -29,6 +29,7 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
     // UI elements
     protected TextView latView;
     protected TextView lonView;
+    protected TextView elevView;
     protected TextView altView;
     protected ImageView crosshairs;
     protected ViewGroup overlay;
@@ -60,6 +61,7 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
         this.overlay.setVisibility(View.VISIBLE);
         this.latView = (TextView) findViewById(R.id.lat_value);
         this.lonView = (TextView) findViewById(R.id.lon_value);
+        this.elevView = (TextView) findViewById(R.id.elev_value);
         this.altView = (TextView) findViewById(R.id.alt_value);
         ObjectAnimator fadeOut = ObjectAnimator.ofFloat(this.crosshairs, "alpha", 0f).setDuration(1500);
         fadeOut.setStartDelay((long) 500);
@@ -135,6 +137,7 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {
         latView.setText(formatLatitude(lookAt.latitude));
         lonView.setText(formatLongitude(lookAt.longitude));
+        elevView.setText(formatElevaton(wwd.getGlobe().getElevationAtLocation(lookAt.latitude, lookAt.longitude)));
         altView.setText(formatAltitude(camera.altitude));
     }
 
@@ -147,6 +150,7 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
         int color = (eventAction == WorldWind.NAVIGATOR_STOPPED) ? 0xA0FFFF00 /*semi-transparent yellow*/ : Color.YELLOW;
         latView.setTextColor(color);
         lonView.setTextColor(color);
+        elevView.setTextColor(color);
         altView.setTextColor(color);
     }
 
@@ -158,6 +162,12 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
     protected String formatLongitude(double longitude) {
         int sign = (int) Math.signum(longitude);
         return String.format("%7.3f°%s", (longitude * sign), (sign >= 0.0 ? "E" : "W"));
+    }
+
+    protected String formatElevaton(double elevation) {
+        return String.format("Alt: %,.0f %s",
+                (elevation < 100000 ? elevation : elevation / 1000),
+                (elevation < 100000 ? "m" : "km"));
     }
 
     protected String formatAltitude(double altitude) {

--- a/worldwind-examples/src/main/res/layout/globe_content.xml
+++ b/worldwind-examples/src/main/res/layout/globe_content.xml
@@ -83,6 +83,23 @@
             android:text="@string/spacer"/>
 
         <TextView
+            android:id="@+id/elev_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:shadowColor="#000000"
+            android:shadowRadius="2"
+            android:shadowDx="0"
+            android:shadowDy="0"
+            android:singleLine="true"/>
+
+        <TextView
+            android:id="@+id/spacer3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:text="@string/spacer"/>
+
+        <TextView
             android:id="@+id/alt_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicFrameController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicFrameController.java
@@ -65,7 +65,6 @@ public class BasicFrameController implements FrameController {
         // picked object ID and the intersection position.
         if (rc.pickRay != null && rc.terrain.intersect(rc.pickRay, this.pickPoint)) {
             rc.globe.cartesianToGeographic(this.pickPoint.x, this.pickPoint.y, this.pickPoint.z, this.pickPos);
-            this.pickPos.altitude = 0; // report the actual altitude, which may not lie on the terrain's surface
             rc.offerPickedObject(PickedObject.fromTerrain(pickedObjectId, this.pickPos));
         }
     }

--- a/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEventSupport.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEventSupport.java
@@ -41,6 +41,14 @@ public class NavigatorEventSupport {
         }
     });
 
+    protected Handler moveHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
+        @Override
+        public boolean handleMessage(Message msg) {
+            onNavigatorMoved();
+            return false;
+        }
+    });
+
     public NavigatorEventSupport(WorldWindow wwd) {
         if (wwd == null) {
             throw new IllegalArgumentException(
@@ -53,6 +61,7 @@ public class NavigatorEventSupport {
     public void reset() {
         this.lastModelview = null;
         this.stopHandler.removeMessages(0 /*what*/);
+        this.moveHandler.removeMessages(0 /*what*/);
 
         if (this.lastTouchEvent != null) {
             this.lastTouchEvent.recycle();
@@ -113,10 +122,14 @@ public class NavigatorEventSupport {
 
         if (this.lastModelview == null) { // this is the first frame; copy the frame's modelview
             this.lastModelview = new Matrix4(rc.modelview);
+            // Notify listeners with stopped event on first frame
+            this.stopHandler.removeMessages(0 /*what*/);
+            this.stopHandler.sendEmptyMessage(0 /*what*/);
         } else if (!this.lastModelview.equals(rc.modelview)) { // the frame's modelview has changed
             this.lastModelview.set(rc.modelview);
             // Notify the listeners of a navigator moved event.
-            this.onNavigatorMoved();
+            this.moveHandler.removeMessages(0 /*what*/);
+            this.moveHandler.sendEmptyMessage(0/*what*/);
             // Schedule a navigator stopped event after a specified delay in milliseconds.
             this.stopHandler.removeMessages(0 /*what*/);
             this.stopHandler.sendEmptyMessageDelayed(0 /*what*/, this.stoppedEventDelay);

--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
@@ -75,7 +75,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
     protected double fieldOfView = 45;
 
-    protected Navigator navigator = new Navigator();
+    protected Navigator navigator = new Navigator(this);
 
     protected NavigatorEventSupport navigatorEvents = new NavigatorEventSupport(this);
 
@@ -387,6 +387,10 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
         // TODO provide a mechanism for the old cache to evict its entries
         this.renderResourceCache = cache;
+    }
+
+    public Viewport getViewport() {
+        return this.viewport;
     }
 
     /**

--- a/worldwind/src/main/java/gov/nasa/worldwind/globe/Globe.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/globe/Globe.java
@@ -320,4 +320,20 @@ public class Globe {
 
         return this.projection.intersect(this, line, result);
     }
+
+    /**
+     * Determine terrain altitude in specified geographic point from elevation model
+     *
+     * @param latitude  location latitude
+     * @param longitude location longitude
+     *
+     * @return Elevation in meters in specified location
+     */
+    public double getElevationAtLocation(double latitude, double longitude) {
+        // Use 1E-15 below because sector can not have zero deltas
+        Sector sector = Sector.fromDegrees(latitude, longitude, 1E-15, 1E-15);
+        float[] heights = new float[1];
+        this.getElevationModel().getHeightGrid(sector, 1, 1, heights);
+        return heights[0];
+    }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/globe/Globe.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/globe/Globe.java
@@ -32,6 +32,10 @@ public class Globe {
      */
     protected GeographicProjection projection;
 
+    private final float[] scratchHeights = new float[1];
+
+    private final Sector scratchSector = new Sector();
+
     /**
      * Constructs a globe with a specified reference ellipsoid and projection.
      *
@@ -331,9 +335,8 @@ public class Globe {
      */
     public double getElevationAtLocation(double latitude, double longitude) {
         // Use 1E-15 below because sector can not have zero deltas
-        Sector sector = Sector.fromDegrees(latitude, longitude, 1E-15, 1E-15);
-        float[] heights = new float[1];
-        this.getElevationModel().getHeightGrid(sector, 1, 1, heights);
-        return heights[0];
+        this.scratchSector.set(latitude, longitude, 1E-15, 1E-15);
+        this.getElevationModel().getHeightGrid(this.scratchSector, 1, 1, this.scratchHeights);
+        return this.scratchHeights[0];
     }
 }


### PR DESCRIPTION
### Description of the Change
Added globe.getElevationAtLocation() method to determine real (not-tessellated) elevation at specified location.
Fixed GL near clip distance calculation and limit Navigator to avoid camera below terrain.
Fixed lookAt position calculation for gestures to rotate around point on terrain (not at zero altitude point).
Add Elevation value output into exabple application.  

### Why Should This Be In Core?
There was a terrain visualization implemented, but it did not used in camera clip distance calculation and during gestures processing.

### Benefits
Correct behavior of camera respecting terrain elevation.

### Potential Drawbacks
None

### Applicable Issues
#9
#10