### PR TITLE
Remove low-pass filter from gestures, especially from RotationRecognizer

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/GestureRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/GestureRecognizer.java
@@ -37,8 +37,6 @@ public class GestureRecognizer {
 
     protected List<GestureListener> listenerList = new ArrayList<>();
 
-    protected float lowPassWeight = 0.4f;
-
     @WorldWind.GestureState
     private int state = WorldWind.POSSIBLE;
 
@@ -244,12 +242,10 @@ public class GestureRecognizer {
 
     protected void handleActionMove(MotionEvent event) {
         this.eventCentroid(event, this.centroidArray);
-        float dx = this.centroidArray[0] - this.startX + this.centroidShiftX;
-        float dy = this.centroidArray[1] - this.startY + this.centroidShiftY;
+        this.translationX = this.centroidArray[0] - this.startX + this.centroidShiftX;
+        this.translationY = this.centroidArray[1] - this.startY + this.centroidShiftY;
         this.x = this.centroidArray[0];
         this.y = this.centroidArray[1];
-        this.translationX = this.lowPassFilter(this.translationX, dx);
-        this.translationY = this.lowPassFilter(this.translationY, dy);
 
         this.actionMove(event);
     }
@@ -316,11 +312,6 @@ public class GestureRecognizer {
         result[0] = x / count;
         result[1] = y / count;
         return result;
-    }
-
-    protected float lowPassFilter(float value, float newValue) {
-        float w = this.lowPassWeight;
-        return value * (1 - w) + newValue * w;
     }
 
     protected void actionDown(MotionEvent event) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/PinchRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/PinchRecognizer.java
@@ -68,8 +68,7 @@ public class PinchRecognizer extends GestureRecognizer {
                 }
             } else if (state == WorldWind.BEGAN || state == WorldWind.CHANGED) {
                 float distance = this.currentPinchDistance(event);
-                float newScale = Math.abs(distance / this.referenceDistance);
-                this.scale = this.lowPassFilter(this.scale, newScale);
+                this.scale = Math.abs(distance / this.referenceDistance);
                 this.transitionToState(event, WorldWind.CHANGED);
             }
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/RotationRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/RotationRecognizer.java
@@ -66,8 +66,7 @@ public class RotationRecognizer extends GestureRecognizer {
                 }
             } else if (state == WorldWind.BEGAN || state == WorldWind.CHANGED) {
                 float angle = this.currentTouchAngle(event);
-                float newRotation = (float) WWMath.normalizeAngle180(angle - this.referenceAngle);
-                this.rotation = this.lowPassFilter(this.rotation, newRotation);
+                this.rotation = (float) WWMath.normalizeAngle180(angle - this.referenceAngle);
                 this.transitionToState(event, WorldWind.CHANGED);
             }
         }


### PR DESCRIPTION
### Description of the Change
Remove low-pass filter from gestures, especially from RotationRecognizer.

### Why Should This Be In Core?
It makes a bug during rotation gesture over 360 degrees.

### Benefits
Normal user input behavior.

### Potential Drawbacks
None

### Applicable Issues
#5 