### PR TITLE
Added MercatorTiledImageLayer support.

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
@@ -1,0 +1,142 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import android.graphics.Bitmap;
+
+import java.util.Collection;
+
+import gov.nasa.worldwind.render.ImageSource;
+import gov.nasa.worldwind.render.ImageTile;
+import gov.nasa.worldwind.util.Level;
+import gov.nasa.worldwind.util.LevelSet;
+import gov.nasa.worldwind.util.Logger;
+import gov.nasa.worldwind.util.Tile;
+import gov.nasa.worldwind.util.TileFactory;
+
+class MercatorImageTile extends ImageTile implements ImageSource.Transformer {
+
+    /**
+     * Constructs a tile with a specified sector, level, row and column.
+     *
+     * @param sector the sector spanned by the tile
+     * @param level  the tile's level in a {@link LevelSet}
+     * @param row    the tile's row within the specified level
+     * @param column the tile's column within the specified level
+     */
+    MercatorImageTile(MercatorSector sector, Level level, int row, int column) {
+        super(sector, level, row, column);
+    }
+
+    /**
+     * Creates all Mercator tiles for a specified level within a {@link LevelSet}.
+     *
+     * @param level       the level to create the tiles for
+     * @param tileFactory the tile factory to use for creating tiles.
+     * @param result      an pre-allocated Collection in which to store the results
+     */
+    static void assembleMercatorTilesForLevel(Level level, TileFactory tileFactory, Collection<Tile> result) {
+        if (level == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingLevel"));
+        }
+
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingTileFactory"));
+        }
+
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingResult"));
+        }
+
+        // NOTE LevelSet.sector is final Sector attribute and thus can not be cast to MercatorSector!
+        MercatorSector sector = MercatorSector.fromSector(level.parent.sector);
+        double dLat = level.tileDelta / 2;
+        double dLon = level.tileDelta;
+
+        int firstRow = Tile.computeRow(dLat, sector.minLatitude());
+        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude());
+        int firstCol = Tile.computeColumn(dLon, sector.minLongitude());
+        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude());
+
+        double deltaLat = dLat / 90;
+        double d1 = sector.minLatPercent() + deltaLat * firstRow;
+        for (int row = firstRow; row <= lastRow; row++) {
+            double d2 = d1 + deltaLat;
+            double t1 = sector.minLongitude() + (firstCol * dLon);
+            for (int col = firstCol; col <= lastCol; col++) {
+                double t2;
+                t2 = t1 + dLon;
+                result.add(tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), level, row, col));
+                t1 = t2;
+            }
+            d1 = d2;
+        }
+    }
+
+    /**
+     * Returns the four children formed by subdividing this tile. This tile's sector is subdivided into four quadrants
+     * as follows: Southwest; Southeast; Northwest; Northeast. A new tile is then constructed for each quadrant and
+     * configured with the next level within this tile's LevelSet and its corresponding row and column within that
+     * level. This returns null if this tile's level is the last level within its {@link LevelSet}.
+     *
+     * @param tileFactory the tile factory to use to create the children
+     *
+     * @return an array containing the four child tiles, or null if this tile's level is the last level
+     */
+    @Override
+    public Tile[] subdivide(TileFactory tileFactory) {
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "subdivide", "missingTileFactory"));
+        }
+
+        Level childLevel = this.level.nextLevel();
+        if (childLevel == null) {
+            return null;
+        }
+
+        MercatorSector sector = (MercatorSector) this.sector;
+
+        double d0 = sector.minLatPercent();
+        double d2 = sector.maxLatPercent();
+        double d1 = d0 + (d2 - d0) / 2.0;
+
+        double t0 = sector.minLongitude();
+        double t2 = sector.maxLongitude();
+        double t1 = 0.5 * (t0 + t2);
+
+        int northRow = 2 * this.row;
+        int southRow = northRow + 1;
+        int westCol = 2 * this.column;
+        int eastCol = westCol + 1;
+
+        Tile[] children = new Tile[4];
+        children[0] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t0, t1), childLevel, northRow, westCol);
+        children[1] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t1, t2), childLevel, northRow, eastCol);
+        children[2] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t0, t1), childLevel, southRow, westCol);
+        children[3] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), childLevel, southRow, eastCol);
+
+        return children;
+    }
+
+    @Override
+    public Bitmap transform(Bitmap bitmap) {
+        // Re-project mercator tile to equirectangular
+        Bitmap trans = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), bitmap.getConfig());
+        double miny = ((MercatorSector) sector).minLatPercent();
+        double maxy = ((MercatorSector) sector).maxLatPercent();
+        for (int y = 0; y < bitmap.getHeight(); y++) {
+            double sy = 1.0 - y / (double) (bitmap.getHeight() - 1);
+            double lat = sy * (sector.maxLatitude() - sector.minLatitude()) + sector.minLatitude();
+            double dy = 1.0 - (MercatorSector.gudermannianInverse(lat) - miny) / (maxy - miny);
+            dy = Math.max(0.0, Math.min(1.0, dy));
+            int iy = (int) (dy * (bitmap.getHeight() - 1));
+            for (int x = 0; x < bitmap.getWidth(); x++) {
+                trans.setPixel(x, y, bitmap.getPixel(x, iy));
+            }
+        }
+        return trans;
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
@@ -1,0 +1,47 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.geom.Sector;
+
+public class MercatorSector extends Sector {
+
+    private final double minLatPercent, maxLatPercent;
+
+    private MercatorSector(double minLatPercent, double maxLatPercent,
+                           double minLongitude, double maxLongitude) {
+        this.minLatPercent = minLatPercent;
+        this.maxLatPercent = maxLatPercent;
+        this.minLatitude = gudermannian(minLatPercent);
+        this.maxLatitude = gudermannian(maxLatPercent);
+        this.minLongitude = minLongitude;
+        this.maxLongitude = maxLongitude;
+    }
+
+    public static MercatorSector fromDegrees(double minLatPercent, double maxLatPercent,
+                                             double minLongitude, double maxLongitude) {
+        return new MercatorSector(minLatPercent, maxLatPercent, minLongitude, maxLongitude);
+    }
+
+    static MercatorSector fromSector(Sector sector) {
+        return new MercatorSector(gudermannianInverse(sector.minLatitude()),
+                gudermannianInverse(sector.maxLatitude()),
+                sector.minLongitude(), sector.maxLongitude());
+    }
+
+    static double gudermannianInverse(double latitude) {
+        return Math.log(Math.tan(Math.PI / 4.0 + Math.toRadians(latitude) / 2.0)) / Math.PI;
+    }
+
+    private static double gudermannian(double percent) {
+        return Math.toDegrees(Math.atan(Math.sinh(percent * Math.PI)));
+    }
+
+    double minLatPercent() {
+        return minLatPercent;
+    }
+
+    double maxLatPercent()
+    {
+        return maxLatPercent;
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
@@ -1,0 +1,44 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Sector;
+import gov.nasa.worldwind.layer.RenderableLayer;
+import gov.nasa.worldwind.render.ImageOptions;
+import gov.nasa.worldwind.render.ImageSource;
+import gov.nasa.worldwind.util.Level;
+import gov.nasa.worldwind.util.LevelSet;
+import gov.nasa.worldwind.util.Tile;
+import gov.nasa.worldwind.util.TileFactory;
+
+public abstract class MercatorTiledImageLayer extends RenderableLayer implements TileFactory {
+
+    private static final double FULL_SPHERE = 360;
+
+    private final int firstLevelOffset;
+
+    public MercatorTiledImageLayer(String name, int numLevels, int firstLevelOffset, int tileSize, boolean overlay) {
+        super(name);
+        this.setPickEnabled(false);
+        this.firstLevelOffset = firstLevelOffset;
+
+        MercatorTiledSurfaceImage surfaceImage = new MercatorTiledSurfaceImage();
+        surfaceImage.setLevelSet(new LevelSet(
+                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2),
+                FULL_SPHERE / (1 << firstLevelOffset), numLevels - firstLevelOffset, tileSize, tileSize));
+        surfaceImage.setTileFactory(this);
+        if(!overlay) {
+            surfaceImage.setImageOptions(new ImageOptions(WorldWind.RGB_565)); // reduce memory usage by using a 16-bit configuration with no alpha
+        }
+        this.addRenderable(surfaceImage);
+    }
+
+    @Override
+    public Tile createTile(Sector sector, Level level, int row, int column) {
+        MercatorImageTile tile = new MercatorImageTile((MercatorSector) sector, level, row, column);
+        tile.setImageSource(ImageSource.fromUrl(getImageSourceUrl(column, (1 << (level.levelNumber + firstLevelOffset)) - 1 - row, level.levelNumber + firstLevelOffset), tile));
+        return tile;
+    }
+
+    protected abstract String getImageSourceUrl(int x, int y, int z);
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledSurfaceImage.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledSurfaceImage.java
@@ -1,0 +1,16 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.shape.TiledSurfaceImage;
+import gov.nasa.worldwind.util.Level;
+
+public class MercatorTiledSurfaceImage extends TiledSurfaceImage {
+
+    @Override
+    protected void createTopLevelTiles() {
+        Level firstLevel = this.levelSet.firstLevel();
+        if (firstLevel != null) {
+            MercatorImageTile.assembleMercatorTilesForLevel(firstLevel, this.tileFactory, this.topLevelTiles);
+        }
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/ImageRetriever.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/ImageRetriever.java
@@ -43,6 +43,12 @@ public class ImageRetriever extends Retriever<ImageSource, ImageOptions, Bitmap>
             Bitmap bitmap = this.decodeImage(imageSource, imageOptions);
 
             if (bitmap != null) {
+                // Apply bitmap transformation if required
+                ImageSource.Transformer transformer = imageSource.getTransformer();
+                if (transformer != null) {
+                    bitmap = transformer.transform(bitmap);
+                }
+
                 callback.retrievalSucceeded(this, imageSource, imageOptions, bitmap);
             } else {
                 callback.retrievalFailed(this, imageSource, null); // failed but no exception

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
@@ -50,6 +50,13 @@ public class ImageSource {
         Bitmap createBitmap();
     }
 
+    /**
+     * Interface which allows to do post transformations with retrieved image.
+     */
+    public interface Transformer {
+        Bitmap transform(Bitmap bitmap);
+    }
+
     protected static final HashMap<Object, BitmapFactory> lineStippleFactories = new HashMap<>();
 
     protected static final int TYPE_UNRECOGNIZED = 0;
@@ -67,6 +74,8 @@ public class ImageSource {
     protected int type = TYPE_UNRECOGNIZED;
 
     protected Object source;
+
+    protected Transformer transformer;
 
     protected ImageSource() {
     }
@@ -239,6 +248,16 @@ public class ImageSource {
             imageSource.source = source;
             return imageSource;
         }
+    }
+
+    public static ImageSource fromUrl(String urlString, Transformer transformer) {
+        ImageSource imageSource = fromUrl(urlString);
+        imageSource.transformer = transformer;
+        return imageSource;
+    }
+
+    Transformer getTransformer() {
+        return transformer;
     }
 
     @Override


### PR DESCRIPTION
### Description of the Change
Added `MercatorTiledImageLayer` and its related components to easily connect popular tile sources such as OpenStreetMap, Google etc. 

### Why Should This Be In Core?
Extends the general usefulness of the SDK.

### Benefits
Adds the capability to use maps and imagery provided in the Mercator projection.

### Potential Drawbacks
Re-projected tiles are not cached in a persistent cache, because Android SDK has no sdcard cache. Re-projection is very resource intensive in low-end devices. 

### Applicable Issues
Closes #12 