### PR TITLE
Update dependencies and rename artifact group to earth.worldwind.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
   components:
     - platform-tools      # latest SDK platform-tools
     - tools               # latest SDK tools
-    - android-23          # SDK version used to compile the project
+    - android-28          # SDK version used to compile the project
     - build-tools-28.0.3  # minimum build tools compatible with Android Gradle plugin 3.3.x
     - extra-android-support
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -17,6 +17,14 @@ allprojects {
         google()
         jcenter()
     }
+}
+
+ext {
+    minSdkVersion = 16
+    targetSdkVersion = 28
+    supportLibVersion = '28.0.0'
+    versionCode = 11
+    versionName = '0.9.0-SNAPSHOT'
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 26 12:20:33 PDT 2019
+#Tue Oct 22 21:31:31 EEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/worldwind-examples/build.gradle
+++ b/worldwind-examples/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion rootProject.ext.targetSdkVersion
     defaultConfig {
         applicationId 'gov.nasa.worldwindx.examples'
-        minSdkVersion 23
-        targetSdkVersion 23
-        versionCode 11
-        versionName '0.9.0-SNAPSHOT'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
     }
     buildTypes {
         release {
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     implementation project(':worldwind')
-    implementation 'com.android.support:appcompat-v7:23.4.0'
-    implementation 'com.android.support:design:23.4.0'
-    implementation 'mil.army.missioncommand:mil-sym-android-renderer:0.1.36'
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:design:${rootProject.ext.supportLibVersion}"
+    implementation 'mil.army.missioncommand:mil-sym-android-renderer:0.1.46'
 }

--- a/worldwind-tutorials/build.gradle
+++ b/worldwind-tutorials/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion rootProject.ext.targetSdkVersion
     defaultConfig {
         applicationId 'gov.nasa.worldwindx.tutorials'
-        minSdkVersion 23
-        targetSdkVersion 23
-        versionCode 11
-        versionName '0.9.0-SNAPSHOT'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
     }
     buildTypes {
         release {
@@ -29,6 +29,6 @@ android {
 
 dependencies {
     implementation project(':worldwind')
-    implementation 'com.android.support:appcompat-v7:23.4.0'
-    implementation 'com.android.support:design:23.4.0'
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:design:${rootProject.ext.supportLibVersion}"
 }

--- a/worldwind/build.gradle
+++ b/worldwind/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
     dependencies {
         // Required by the Artifactory gradle plugin for publishing to OJO
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.10.0'
     }
 }
 
 plugins {
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
 }
 
 apply plugin: 'com.android.library'
@@ -14,12 +14,12 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion rootProject.ext.targetSdkVersion
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
-        versionCode 11
-        versionName '0.9.0-SNAPSHOT'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
@@ -47,15 +47,15 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation "com.android.support:support-annotations:${rootProject.ext.supportLibVersion}"
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.0.43-beta'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
     // PowerMockito is required to mock static methods like Logger.log
-    testImplementation('org.powermock:powermock-api-mockito:1.6.2') {
+    testImplementation('org.powermock:powermock-api-mockito2:2.0.4') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'
     }
-    testImplementation('org.powermock:powermock-module-junit4:1.6.2') {
+    testImplementation('org.powermock:powermock-module-junit4:2.0.4') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'
     }
@@ -63,23 +63,25 @@ dependencies {
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }
 
-publishing {
-    publications {
-        bintray(MavenPublication) {
-            artifact bundleReleaseAar
-            artifact bundleSourcesJar
-            artifact bundleJavadocJar
-            groupId 'gov.nasa.worldwind.android'
-            artifactId 'worldwind'
-            version android.defaultConfig.versionName
-            pom.withXml {
-                def dependenciesNode = asNode().appendNode('dependencies')
-                // Iterate over the compile dependencies
-                configurations.compile.allDependencies.each {
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.group)
-                    dependencyNode.appendNode('artifactId', it.name)
-                    dependencyNode.appendNode('version', it.version)
+project.afterEvaluate {
+    publishing {
+        publications {
+            bintray(MavenPublication) {
+                artifact bundleReleaseAar
+                artifact bundleSourcesJar
+                artifact bundleJavadocJar
+                groupId 'earth.worldwind'
+                artifactId 'worldwind-android'
+                version android.defaultConfig.versionName
+                pom.withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    // Iterate over the compile dependencies
+                    configurations.compile.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description of the Change
Update to target SDK version 28.
Update to Gradle 5.1.1.
Update all dependencies to latest versions.
Rename artifact group to "earth.worldwind".

### Why Should This Be In Core?
It requires to fix Travis-CI build.

### Benefits
Allow to understand a build status.

### Potential Drawbacks
None

### Applicable Issues
None