### PR TITLE
Refactor camera management and some UX behaviour

### DIFF
--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/AbstractMainActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/AbstractMainActivity.java
@@ -127,8 +127,8 @@ public abstract class AbstractMainActivity extends AppCompatActivity
         this.navigationView.setCheckedItem(selectedItemId);
         // Use this Activity's Handler to periodically print the FrameMetrics.
         this.handler.sendEmptyMessageDelayed(PRINT_METRICS, PRINT_METRICS_DELAY);
-        // Restore the navigator's camera state from previously saved session data
-        this.restoreNavigatorState();
+        // Restore camera state from previously saved session data
+        this.restoreCameraState();
     }
 
     @Override
@@ -136,8 +136,8 @@ public abstract class AbstractMainActivity extends AppCompatActivity
         super.onPause();
         // Stop printing frame metrics when this activity is paused.
         this.handler.removeMessages(PRINT_METRICS);
-        // Save the navigator's camera state.
-        this.saveNavigatorState();
+        // Save camera state.
+        this.saveCameraState();
     }
 
     @Override
@@ -163,9 +163,9 @@ public abstract class AbstractMainActivity extends AppCompatActivity
     }
 
     /**
-     * Saves the Navigator's camera data to a SharedPreferences object.
+     * Saves camera state to a SharedPreferences object.
      */
-    protected void saveNavigatorState() {
+    protected void saveCameraState() {
         WorldWindow wwd = this.getWorldWindow();
         if (wwd != null) {
             SharedPreferences preferences = this.getPreferences(MODE_PRIVATE);
@@ -175,7 +175,7 @@ public abstract class AbstractMainActivity extends AppCompatActivity
             editor.putLong(SESSION_TIMESTAMP, getSessionTimestamp());
 
             // Write the camera data
-            Camera camera = wwd.getNavigator().getAsCamera(wwd.getGlobe(), new Camera());
+            Camera camera = wwd.getCamera();
             editor.putFloat(CAMERA_LATITUDE, (float) camera.position.latitude);
             editor.putFloat(CAMERA_LONGITUDE, (float) camera.position.longitude);
             editor.putFloat(CAMERA_ALTITUDE, (float) camera.position.altitude);
@@ -189,9 +189,9 @@ public abstract class AbstractMainActivity extends AppCompatActivity
     }
 
     /**
-     * Restores the Navigator's camera state from a SharedPreferences object.
+     * Restores camera state from a SharedPreferences object.
      */
-    protected void restoreNavigatorState() {
+    protected void restoreCameraState() {
         WorldWindow wwd = this.getWorldWindow();
         if (wwd != null) {
             SharedPreferences preferences = this.getPreferences(MODE_PRIVATE);
@@ -215,8 +215,7 @@ public abstract class AbstractMainActivity extends AppCompatActivity
             }
 
             // Restore the camera state.
-            Camera camera = new Camera(lat, lon, alt, altMode, heading, tilt, roll);
-            wwd.getNavigator().setAsCamera(wwd.getGlobe(), camera);
+            wwd.getCamera().set(lat, lon, alt, altMode, heading, tilt, roll);
         }
     }
 

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/AbstractMainActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/AbstractMainActivity.java
@@ -176,9 +176,9 @@ public abstract class AbstractMainActivity extends AppCompatActivity
 
             // Write the camera data
             Camera camera = wwd.getNavigator().getAsCamera(wwd.getGlobe(), new Camera());
-            editor.putFloat(CAMERA_LATITUDE, (float) camera.latitude);
-            editor.putFloat(CAMERA_LONGITUDE, (float) camera.longitude);
-            editor.putFloat(CAMERA_ALTITUDE, (float) camera.altitude);
+            editor.putFloat(CAMERA_LATITUDE, (float) camera.position.latitude);
+            editor.putFloat(CAMERA_LONGITUDE, (float) camera.position.longitude);
+            editor.putFloat(CAMERA_ALTITUDE, (float) camera.position.altitude);
             editor.putFloat(CAMERA_HEADING, (float) camera.heading);
             editor.putFloat(CAMERA_TILT, (float) camera.tilt);
             editor.putFloat(CAMERA_ROLL, (float) camera.roll);

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
@@ -47,10 +47,6 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
         }
 
         @Override
-        public void setWorldWindow(WorldWindow wwd) {
-        }
-
-        @Override
         public boolean onTouchEvent(MotionEvent event) {
             return false;
         }

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
@@ -66,34 +66,23 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
 
         protected Camera curCamera = new Camera();
 
-        protected Position beginPos = new Position();
-
-        protected Position endPos = new Position();
-
-        protected Position curPos = new Position();
-
         protected int steps;
 
         public AnimateCameraCommand(WorldWindow wwd, Camera end, int steps) {
             this.wwd = wwd;
             this.endCamera.set(end);
-            this.endPos.set(end.latitude, end.longitude, end.altitude);
             this.steps = steps;
         }
 
         @Override
         public void run() {
             this.wwd.getNavigator().getAsCamera(this.wwd.getGlobe(), this.beginCamera);
-            this.beginPos.set(this.beginCamera.latitude, this.beginCamera.longitude, this.beginCamera.altitude);
 
             for (int i = 0; i < this.steps; i++) {
 
                 double amount = (double) i / (double) (this.steps - 1);
-                this.beginPos.interpolateAlongPath(this.endPos, WorldWind.GREAT_CIRCLE, amount, this.curPos);
+                this.beginCamera.position.interpolateAlongPath(this.endCamera.position, WorldWind.GREAT_CIRCLE, amount, this.curCamera.position);
 
-                this.curCamera.latitude = this.curPos.latitude;
-                this.curCamera.longitude = this.curPos.longitude;
-                this.curCamera.altitude = this.curPos.altitude;
                 this.curCamera.heading = WWMath.interpolateAngle360(amount, this.beginCamera.heading, this.endCamera.heading);
                 this.curCamera.tilt = WWMath.interpolateAngle180(amount, this.beginCamera.tilt, this.endCamera.tilt);
                 this.curCamera.roll = WWMath.interpolateAngle180(amount, this.beginCamera.roll, this.endCamera.roll);

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicPerformanceBenchmarkActivity.java
@@ -60,23 +60,28 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
 
         protected WorldWindow wwd;
 
-        protected Camera beginCamera = new Camera();
+        protected Camera beginCamera;
 
-        protected Camera endCamera = new Camera();
+        protected Camera endCamera;
 
-        protected Camera curCamera = new Camera();
+        protected Camera curCamera;
 
         protected int steps;
 
         public AnimateCameraCommand(WorldWindow wwd, Camera end, int steps) {
             this.wwd = wwd;
+
+            this.beginCamera = new Camera(wwd);
+            this.endCamera = new Camera(wwd);
+            this.curCamera = new Camera(wwd);
+
             this.endCamera.set(end);
             this.steps = steps;
         }
 
         @Override
         public void run() {
-            this.wwd.getNavigator().getAsCamera(this.wwd.getGlobe(), this.beginCamera);
+            this.beginCamera.set(this.wwd.getCamera());
 
             for (int i = 0; i < this.steps; i++) {
 
@@ -100,7 +105,7 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
 
         private WorldWindow wwd;
 
-        private Camera camera = new Camera();
+        private Camera camera;
 
         private SetCameraCommand() {
         }
@@ -116,6 +121,7 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
 
         private SetCameraCommand set(WorldWindow wwd, Camera camera) {
             this.wwd = wwd;
+            this.camera = new Camera(wwd);
             this.camera.set(camera);
             return this;
         }
@@ -127,7 +133,7 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
 
         @Override
         public void run() {
-            this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
+            this.wwd.getCamera().set(this.camera);
             this.wwd.requestRedraw();
             pool.release(this.reset());
         }
@@ -238,12 +244,12 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
         exec.execute(new ClearFrameMetricsCommand(wwd));
 
         // After a 1/2 second delay, fly to NASA Ames Research Center over 100 frames.
-        Camera cam = new Camera(arc.latitude, arc.longitude, 10e3, WorldWind.ABSOLUTE, 0, 0, 0);
+        Camera cam = new Camera(this.getWorldWindow()).set(arc.latitude, arc.longitude, 10e3, WorldWind.ABSOLUTE, 0, 0, 0);
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
 
         // After a 1/2 second delay, rotate the camera to look at NASA Goddard Space Flight Center over 50 frames.
         double azimuth = arc.greatCircleAzimuth(gsfc);
-        cam = new Camera(arc.latitude, arc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 70, 0);
+        cam = new Camera(this.getWorldWindow()).set(arc.latitude, arc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 70, 0);
         exec.execute(new SleepCommand(500));
         exec.execute(new AnimateCameraCommand(wwd, cam, 50));
 
@@ -251,27 +257,27 @@ public class BasicPerformanceBenchmarkActivity extends GeneralGlobeActivity {
         Location midLoc = arc.interpolateAlongPath(gsfc, WorldWind.GREAT_CIRCLE, 0.5, new Location());
         azimuth = midLoc.greatCircleAzimuth(gsfc);
         exec.execute(new SleepCommand(500));
-        cam = new Camera(midLoc.latitude, midLoc.longitude, 1000e3, WorldWind.ABSOLUTE, azimuth, 0, 0);
+        cam = new Camera(this.getWorldWindow()).set(midLoc.latitude, midLoc.longitude, 1000e3, WorldWind.ABSOLUTE, azimuth, 0, 0);
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
-        cam = new Camera(gsfc.latitude, gsfc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 70, 0);
+        cam = new Camera(this.getWorldWindow()).set(gsfc.latitude, gsfc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 70, 0);
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
 
         // After a 1/2 second delay, rotate the camera to look at ESA Centre for Earth Observation over 50 frames.
         azimuth = gsfc.greatCircleAzimuth(esrin);
-        cam = new Camera(gsfc.latitude, gsfc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 90, 0);
+        cam = new Camera(this.getWorldWindow()).set(gsfc.latitude, gsfc.longitude, 10e3, WorldWind.ABSOLUTE, azimuth, 90, 0);
         exec.execute(new SleepCommand(500));
         exec.execute(new AnimateCameraCommand(wwd, cam, 50));
 
         // After a 1/2 second delay, fly the camera to ESA Centre for Earth Observation over 200 frames.
         midLoc = gsfc.interpolateAlongPath(esrin, WorldWind.GREAT_CIRCLE, 0.5, new Location());
         exec.execute(new SleepCommand(500));
-        cam = new Camera(midLoc.latitude, midLoc.longitude, 1000e3, WorldWind.ABSOLUTE, azimuth, 60, 0);
+        cam = new Camera(this.getWorldWindow()).set(midLoc.latitude, midLoc.longitude, 1000e3, WorldWind.ABSOLUTE, azimuth, 60, 0);
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
-        cam = new Camera(esrin.latitude, esrin.longitude, 100e3, WorldWind.ABSOLUTE, azimuth, 30, 0);
+        cam = new Camera(this.getWorldWindow()).set(esrin.latitude, esrin.longitude, 100e3, WorldWind.ABSOLUTE, azimuth, 30, 0);
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
 
         // After a 1/2 second delay, back the camera out to look at ESA Centre for Earth Observation over 100 frames.
-        cam = new Camera(esrin.latitude, esrin.longitude, 2000e3, WorldWind.ABSOLUTE, 0, 0, 0);
+        cam = new Camera(this.getWorldWindow()).set(esrin.latitude, esrin.longitude, 2000e3, WorldWind.ABSOLUTE, 0, 0, 0);
         exec.execute(new SleepCommand(500));
         exec.execute(new AnimateCameraCommand(wwd, cam, 100));
 

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicStressTestActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/BasicStressTestActivity.java
@@ -8,7 +8,7 @@ package gov.nasa.worldwindx;
 import android.os.Bundle;
 import android.view.Choreographer;
 
-import gov.nasa.worldwind.Navigator;
+import gov.nasa.worldwind.geom.Camera;
 import gov.nasa.worldwind.layer.ShowTessellationLayer;
 
 public class BasicStressTestActivity extends GeneralGlobeActivity implements Choreographer.FrameCallback {
@@ -21,16 +21,16 @@ public class BasicStressTestActivity extends GeneralGlobeActivity implements Cho
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setAboutBoxTitle("About the " + this.getResources().getText(R.string.title_basic_stress_test));
-        this.setAboutBoxText("Continuously moves the navigator in an Easterly direction from a low altitude.");
+        this.setAboutBoxText("Continuously moves the camera in an Easterly direction from a low altitude.");
 
         // Add the ShowTessellation layer to provide some visual feedback regardless of texture details
         this.getWorldWindow().getLayers().addLayer(new ShowTessellationLayer());
 
-        // Initialize the Navigator so that it's looking in the direction of movement and the horizon is visible.
-        Navigator navigator = this.getWorldWindow().getNavigator();
-        navigator.setAltitude(1e3); // 1 km
-        navigator.setHeading(90); // looking east
-        navigator.setTilt(75); // looking at the horizon
+        // Initialize the Camera so that it's looking in the direction of movement and the horizon is visible.
+        Camera camera = this.getWorldWindow().getCamera();
+        camera.position.altitude = 1e3; // 1 km
+        camera.heading = 90; // looking east
+        camera.tilt = 75; // looking at the horizon
     }
 
     @Override
@@ -40,9 +40,9 @@ public class BasicStressTestActivity extends GeneralGlobeActivity implements Cho
             double frameDurationSeconds = (frameTimeNanos - this.lastFrameTimeNanos) * 1.0e-9;
             double cameraDegrees = (frameDurationSeconds * this.cameraDegreesPerSecond);
 
-            // Move the navigator to continuously bring new tiles into view.
-            Navigator navigator = getWorldWindow().getNavigator();
-            navigator.setLongitude(navigator.getLongitude() + cameraDegrees);
+            // Move the camera to continuously bring new tiles into view.
+            Camera camera = getWorldWindow().getCamera();
+            camera.position.longitude += cameraDegrees;
 
             // Redraw the WorldWindow to display the above changes.
             this.getWorldWindow().requestRedraw();
@@ -63,7 +63,7 @@ public class BasicStressTestActivity extends GeneralGlobeActivity implements Cho
     @Override
     protected void onResume() {
         super.onResume();
-        // Use this Activity's Choreographer to animate the Navigator.
+        // Use this Activity's Choreographer to animate the Camera.
         Choreographer.getInstance().postFrameCallback(this);
         this.lastFrameTimeNanos = 0;
     }

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/DayNightCycleActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/DayNightCycleActivity.java
@@ -8,7 +8,7 @@ package gov.nasa.worldwindx;
 import android.os.Bundle;
 import android.view.Choreographer;
 
-import gov.nasa.worldwind.Navigator;
+import gov.nasa.worldwind.geom.Camera;
 import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.layer.LayerList;
 import gov.nasa.worldwindx.experimental.AtmosphereLayer;
@@ -34,7 +34,7 @@ public class DayNightCycleActivity extends BasicGlobeActivity implements Choreog
         super.onCreate(savedInstanceState);
         setAboutBoxTitle("About the " + this.getResources().getText(R.string.title_day_night_cycle));
         setAboutBoxText("Demonstrates how to display a continuous day-night cycle on the WorldWind globe.\n" +
-            "This gradually changes both the Navigator's location and the AtmosphereLayer's light location.");
+            "This gradually changes both the Camera's location and the AtmosphereLayer's light location.");
 
         // Initialize the Atmosphere layer's light location to our custom location. By default the light location is
         // always behind the viewer.
@@ -42,10 +42,10 @@ public class DayNightCycleActivity extends BasicGlobeActivity implements Choreog
         this.atmosphereLayer = (AtmosphereLayer) layers.getLayer(layers.indexOfLayerNamed("Atmosphere"));
         this.atmosphereLayer.setLightLocation(this.sunLocation);
 
-        // Initialize the Navigator so that the sun is behind the viewer.
-        Navigator navigator = this.getWorldWindow().getNavigator();
-        navigator.setLatitude(20);
-        navigator.setLongitude(this.sunLocation.longitude);
+        // Initialize the Camera so that the sun is behind the viewer.
+        Camera camera = this.getWorldWindow().getCamera();
+        camera.position.latitude = 20;
+        camera.position.longitude = this.sunLocation.longitude;
 
         // Use this Activity's Choreographer to animate the day-night cycle.
         Choreographer.getInstance().postFrameCallback(this);
@@ -59,9 +59,9 @@ public class DayNightCycleActivity extends BasicGlobeActivity implements Choreog
             double cameraDegrees = (frameDurationSeconds * this.cameraDegreesPerSecond);
             double lightDegrees = (frameDurationSeconds * this.lightDegreesPerSecond);
 
-            // Move the navigator to simulate the Earth's rotation about its axis.
-            Navigator navigator = getWorldWindow().getNavigator();
-            navigator.setLongitude(navigator.getLongitude() - cameraDegrees);
+            // Move the camera to simulate the Earth's rotation about its axis.
+            Camera camera = getWorldWindow().getCamera();
+            camera.position.longitude -= cameraDegrees;
 
             // Move the sun location to simulate the Sun's rotation about the Earth.
             this.sunLocation.set(this.sunLocation.latitude, this.sunLocation.longitude - lightDegrees);

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
@@ -135,10 +135,10 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
      * @param camera Where the camera is positioned
      */
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {
-        latView.setText(formatLatitude(lookAt.latitude));
-        lonView.setText(formatLongitude(lookAt.longitude));
-        elevView.setText(formatElevaton(wwd.getGlobe().getElevationAtLocation(lookAt.latitude, lookAt.longitude)));
-        altView.setText(formatAltitude(camera.altitude));
+        latView.setText(formatLatitude(lookAt.position.latitude));
+        lonView.setText(formatLongitude(lookAt.position.longitude));
+        elevView.setText(formatElevaton(wwd.getGlobe().getElevationAtLocation(lookAt.position.latitude, lookAt.position.longitude)));
+        altView.setText(formatAltitude(camera.position.altitude));
     }
 
     /**

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/GeneralGlobeActivity.java
@@ -33,9 +33,8 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
     protected TextView altView;
     protected ImageView crosshairs;
     protected ViewGroup overlay;
-    // Use pre-allocated navigator state objects to avoid per-event memory allocations
+    // Use pre-allocated lookAt state object to avoid per-event memory allocations
     private LookAt lookAt = new LookAt();
-    private Camera camera = new Camera();
     // Track the navigation event time so the overlay refresh rate can be throttled
     private long lastEventTime;
     // Animation object used to fade the overlays
@@ -81,12 +80,11 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
                 // and also it is moving but at an (arbitrary) maximum refresh rate of 20 Hz.
                 if (eventAction == WorldWind.NAVIGATOR_STOPPED || elapsedTime > 50) {
 
-                    // Get the current navigator state to apply to the overlays
-                    event.getNavigator().getAsLookAt(wwd.getGlobe(), lookAt);
-                    event.getNavigator().getAsCamera(wwd.getGlobe(), camera);
+                    // Get the current camera state to apply to the overlays
+                    event.getCamera().getAsLookAt(lookAt);
 
                     // Update the overlays
-                    updateOverlayContents(lookAt, camera);
+                    updateOverlayContents(lookAt, event.getCamera());
                     updateOverlayColor(eventAction);
 
                     lastEventTime = currentTime;
@@ -129,9 +127,9 @@ public class GeneralGlobeActivity extends BasicGlobeActivity {
     }
 
     /**
-     * Displays navigator state information in the status overlay views.
+     * Displays camera state information in the status overlay views.
      *
-     * @param lookAt Where the navigator is looking
+     * @param lookAt Where the camera is looking
      * @param camera Where the camera is positioned
      */
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineActivity.java
@@ -14,6 +14,7 @@ import gov.nasa.worldwind.BasicWorldWindowController;
 import gov.nasa.worldwind.PickedObject;
 import gov.nasa.worldwind.PickedObjectList;
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.WorldWindow;
 import gov.nasa.worldwind.geom.Line;
 import gov.nasa.worldwind.geom.LookAt;
 import gov.nasa.worldwind.geom.Position;
@@ -83,7 +84,7 @@ public class OmnidirectionalSightlineActivity extends BasicGlobeActivity {
         this.wwd.getLayers().addLayer(sightlineLayer);
 
         // Override the WorldWindow's built-in navigation behavior with conditional dragging support.
-        this.controller = new SimpleSelectDragNavigateController();
+        this.controller = new SimpleSelectDragNavigateController(this.wwd);
         this.wwd.setWorldWindowController(this.controller);
 
         // And finally, for this demo, position the viewer to look at the sightline position
@@ -132,6 +133,10 @@ public class OmnidirectionalSightlineActivity extends BasicGlobeActivity {
                 return false;
             }
         });
+
+        public SimpleSelectDragNavigateController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the select/drag handlers or the native World Wind navigation handlers.

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineActivity.java
@@ -88,7 +88,7 @@ public class OmnidirectionalSightlineActivity extends BasicGlobeActivity {
 
         // And finally, for this demo, position the viewer to look at the sightline position
         LookAt lookAt = new LookAt().set(pos.latitude, pos.longitude, pos.altitude, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-        this.getWorldWindow().getNavigator().setAsLookAt(this.getWorldWindow().getGlobe(), lookAt);
+        this.getWorldWindow().getCamera().setFromLookAt(lookAt);
     }
 
     /**

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PathsPolygonsLabelsActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PathsPolygonsLabelsActivity.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import gov.nasa.worldwind.BasicWorldWindowController;
 import gov.nasa.worldwind.PickedObjectList;
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.WorldWindow;
 import gov.nasa.worldwind.geom.Offset;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.layer.RenderableLayer;
@@ -69,9 +70,12 @@ public class PathsPolygonsLabelsActivity extends GeneralGlobeActivity {
         FrameLayout globeLayout = (FrameLayout) findViewById(R.id.globe);
         globeLayout.addView(this.statusText);
 
+        // Get a reference to the WorldWindow view
+        WorldWindow wwd = this.getWorldWindow();
+
         // Override the WorldWindow's built-in navigation behavior by adding picking support.
-        this.getWorldWindow().setWorldWindowController(new PickController());
-        this.getWorldWindow().getLayers().addLayer(this.shapesLayer);
+        wwd.setWorldWindowController(new PickController(wwd));
+        wwd.getLayers().addLayer(this.shapesLayer);
 
         // Load the shapes into the renderable layer
         statusText.setText("Loading countries....");
@@ -351,6 +355,10 @@ public class PathsPolygonsLabelsActivity extends GeneralGlobeActivity {
                 return true;
             }
         });
+
+        public PickController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the pick handler or the native WorldWind navigation handlers.

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import gov.nasa.worldwind.BasicWorldWindowController;
 import gov.nasa.worldwind.PickedObject;
 import gov.nasa.worldwind.PickedObjectList;
+import gov.nasa.worldwind.WorldWindow;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.layer.RenderableLayer;
 import gov.nasa.worldwind.render.ImageSource;
@@ -64,8 +65,11 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
         FrameLayout globeLayout = (FrameLayout) findViewById(R.id.globe);
         globeLayout.addView(this.statusText);
 
+        // Get a reference to the WorldWindow view
+        WorldWindow wwd = this.getWorldWindow();
+
         // Override the WorldWindow's built-in navigation behavior by adding picking support.
-        this.getWorldWindow().setWorldWindowController(new PickController());
+        wwd.setWorldWindowController(new PickController(wwd));
 
         new CreatePlacesTask().execute();
     }
@@ -401,6 +405,10 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
                 return false;
             }
         });
+
+        public PickController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the pick handler or the native WorldWind navigation handlers.

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525Activity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525Activity.java
@@ -39,7 +39,7 @@ public class PlacemarksMilStd2525Activity extends GeneralGlobeActivity {
         Position pos = new Position(32.4520, 63.44553, 0);
         LookAt lookAt = new LookAt().set(pos.latitude, pos.longitude, pos.altitude, WorldWind.ABSOLUTE,
             1e5 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-        this.getWorldWindow().getNavigator().setAsLookAt(this.getWorldWindow().getGlobe(), lookAt);
+        this.getWorldWindow().getCamera().setFromLookAt(lookAt);
 
         // The MIL-STD-2525 rendering library takes time initialize, we'll perform this task via the
         // AsyncTask's background thread and then load the symbols in its post execute handler.

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525StressActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525StressActivity.java
@@ -19,7 +19,7 @@ import java.util.Random;
 
 import armyc2.c2sd.renderer.utilities.MilStdAttributes;
 import armyc2.c2sd.renderer.utilities.ModifiersUnits;
-import gov.nasa.worldwind.Navigator;
+import gov.nasa.worldwind.geom.Camera;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.layer.RenderableLayer;
 import gov.nasa.worldwind.layer.ShowTessellationLayer;
@@ -1419,9 +1419,9 @@ public class PlacemarksMilStd2525StressActivity extends GeneralGlobeActivity imp
             double frameDurationSeconds = (frameTimeNanos - this.lastFrameTimeNanos) * 1.0e-9;
             double cameraDegrees = (frameDurationSeconds * this.cameraDegreesPerSecond);
 
-            // Move the navigator to simulate the Earth's rotation about its axis.
-            Navigator navigator = getWorldWindow().getNavigator();
-            navigator.setLongitude(navigator.getLongitude() - cameraDegrees);
+            // Move the camera to simulate the Earth's rotation about its axis.
+            Camera camera = getWorldWindow().getCamera();
+            camera.position.longitude -= cameraDegrees;
 
             // Redraw the WorldWindow to display the above changes.
             this.getWorldWindow().requestRedraw();

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksSelectDragActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksSelectDragActivity.java
@@ -152,7 +152,7 @@ public class PlacemarksSelectDragActivity extends GeneralGlobeActivity {
         WorldWindow wwd = this.getWorldWindow();
 
         // Override the WorldWindow's built-in navigation behavior with conditional dragging support.
-        this.controller = new SelectDragNavigateController();
+        this.controller = new SelectDragNavigateController(wwd);
         wwd.setWorldWindowController(this.controller);
 
         // Add a layer for placemarks to the WorldWindow
@@ -303,6 +303,10 @@ public class PlacemarksSelectDragActivity extends GeneralGlobeActivity {
                 contextMenu();
             }
         });
+
+        public SelectDragNavigateController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the select/drag handlers or the native WorldWind navigation handlers.

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksSelectDragActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksSelectDragActivity.java
@@ -172,7 +172,7 @@ public class PlacemarksSelectDragActivity extends GeneralGlobeActivity {
 
         // And finally, for this demo, position the viewer to look at the placemarks
         LookAt lookAt = new LookAt().set(34.150, -119.150, 0, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-        this.getWorldWindow().getNavigator().setAsLookAt(this.getWorldWindow().getGlobe(), lookAt);
+        this.getWorldWindow().getCamera().setFromLookAt(lookAt);
     }
 
     /**

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksStressTestActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksStressTestActivity.java
@@ -10,7 +10,7 @@ import android.view.Choreographer;
 
 import java.util.Random;
 
-import gov.nasa.worldwind.Navigator;
+import gov.nasa.worldwind.geom.Camera;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.layer.Layer;
 import gov.nasa.worldwind.layer.RenderableLayer;
@@ -94,9 +94,9 @@ public class PlacemarksStressTestActivity extends GeneralGlobeActivity implement
             double frameDurationSeconds = (frameTimeNanos - this.lastFrameTimeNanos) * 1.0e-9;
             double cameraDegrees = (frameDurationSeconds * this.cameraDegreesPerSecond);
 
-            // Move the navigator to simulate the Earth's rotation about its axis.
-            Navigator navigator = getWorldWindow().getNavigator();
-            navigator.setLongitude(navigator.getLongitude() - cameraDegrees);
+            // Move the camera to simulate the Earth's rotation about its axis.
+            Camera camera = getWorldWindow().getCamera();
+            camera.position.longitude -= cameraDegrees;
 
             // Redraw the WorldWindow to display the above changes.
             this.getWorldWindow().requestRedraw();

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/TextureStressTestActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/TextureStressTestActivity.java
@@ -58,9 +58,7 @@ public class TextureStressTestActivity extends BasicGlobeActivity {
         // Position the viewer so that the surface images will be visible as they're added.
         this.firstSector.set(35.0, 10.0, 0.5, 0.5);
         this.sector.set(this.firstSector);
-        this.getWorldWindow().getNavigator().setLatitude(37.5);
-        this.getWorldWindow().getNavigator().setLongitude(15.0);
-        this.getWorldWindow().getNavigator().setAltitude(1.0e6);
+        this.getWorldWindow().getCamera().position.set(37.5, 15.0, 1.0e6);
 
         // Allocate a 32-bit 1024 x 1024 bitmap that we'll use to create all of the OpenGL texture objects in this test.
         int[] colors = new int[1024 * 1024];

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/experimental/AtmosphereLayer.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/experimental/AtmosphereLayer.java
@@ -90,7 +90,7 @@ public class AtmosphereLayer extends AbstractLayer {
         if (this.lightLocation != null) {
             rc.globe.geographicToCartesianNormal(this.lightLocation.latitude, this.lightLocation.longitude, this.activeLightDirection);
         } else {
-            rc.globe.geographicToCartesianNormal(rc.camera.latitude, rc.camera.longitude, this.activeLightDirection);
+            rc.globe.geographicToCartesianNormal(rc.camera.position.latitude, rc.camera.position.longitude, this.activeLightDirection);
         }
     }
 

--- a/worldwind-tutorials/src/main/assets/camera_control_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/camera_control_tutorial.html
@@ -46,7 +46,7 @@ public class CameraControlFragment extends BasicGlobeFragment {
         WorldWindow wwd = super.createWorldWindow();
 
         // Override the default "look at" gesture behavior with a camera centric gesture controller
-        wwd.setWorldWindowController(new CameraController());
+        wwd.setWorldWindowController(new CameraController(wwd));
 
         // Apply camera position above KOXR airport, Oxnard, CA
         wwd.getCamera().set(34.2, -119.2,
@@ -67,6 +67,10 @@ public class CameraControlFragment extends BasicGlobeFragment {
         protected double beginHeading;
 
         protected double beginTilt;
+
+        public CameraController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         @Override
         protected void handlePan(GestureRecognizer recognizer) {

--- a/worldwind-tutorials/src/main/assets/camera_control_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/camera_control_tutorial.html
@@ -19,7 +19,7 @@
     Demonstrates how to override the WorldWindowController gesture controller.
     </p>
 <p>
-    This advanced example uses the Navigator's setAsCamera interface in response to touch event gestures.</p>
+    This advanced example uses the Cameras's interface in response to touch event gestures.</p>
 <ul>
     <li>one-finger pan moves the geographic location of the camera,</li>
     <li>two-finger pinch-zoom adjusts the camera altitude,</li>
@@ -48,21 +48,15 @@ public class CameraControlFragment extends BasicGlobeFragment {
         // Override the default "look at" gesture behavior with a camera centric gesture controller
         wwd.setWorldWindowController(new CameraController());
 
-        // Create a camera position above KOXR airport, Oxnard, CA
-        Camera camera = new Camera();
-        camera.set(34.2, -119.2,
-            10000, WorldWind.ABSOLUTE,
-            90, // Looking east
-            70, // Lookup up from nadir
-            0); // No roll
-
-        // Apply the new camera position
-        Globe globe = wwd.getGlobe();
-        wwd.getNavigator().setAsCamera(globe, camera);
+        // Apply camera position above KOXR airport, Oxnard, CA
+        wwd.getCamera().set(34.2, -119.2,
+                10000, WorldWind.ABSOLUTE,
+                90, // Looking east
+                70, // Lookup up from nadir
+                0); // No roll
 
         return wwd;
     }
-
 
     /**
      * A custom WorldWindController that uses gestures to control the camera directly via the setAsCamera interface
@@ -70,9 +64,9 @@ public class CameraControlFragment extends BasicGlobeFragment {
      */
     private class CameraController extends BasicWorldWindowController {
 
-        protected Camera camera = new Camera();
+        protected double beginHeading;
 
-        protected Camera beginCamera = new Camera();
+        protected double beginTilt;
 
         @Override
         protected void handlePan(GestureRecognizer recognizer) {
@@ -85,12 +79,14 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 this.lastX = 0;
                 this.lastY = 0;
             } else if (state == WorldWind.CHANGED) {
-                // Get the navigator's current position.
-                double lat = this.camera.latitude;
-                double lon = this.camera.longitude;
-                double alt = this.camera.altitude;
+                Camera camera = this.getWorldWindow().getCamera();
 
-                // Convert the translation from screen coordinates to degrees. Use the navigator's range as a metric for
+                // Get the camera's current position.
+                double lat = camera.position.latitude;
+                double lon = camera.position.longitude;
+                double alt = camera.position.altitude;
+
+                // Convert the translation from screen coordinates to degrees. Use the camera's range as a metric for
                 // converting screen pixels to meters, and use the globe's radius for converting from meters to arc degrees.
                 double metersPerPixel = this.wwd.pixelSizeAtDistance(alt);
                 double forwardMeters = (dy - this.lastY) * metersPerPixel;
@@ -102,29 +98,28 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 double forwardDegrees = Math.toDegrees(forwardMeters / globeRadius);
                 double sideDegrees = Math.toDegrees(sideMeters / globeRadius);
 
-                // Adjust the change in latitude and longitude based on the navigator's heading.
-                double heading = this.camera.heading;
+                // Adjust the change in latitude and longitude based on the camera's heading.
+                double heading = camera.heading;
                 double headingRadians = Math.toRadians(heading);
                 double sinHeading = Math.sin(headingRadians);
                 double cosHeading = Math.cos(headingRadians);
                 lat += forwardDegrees * cosHeading - sideDegrees * sinHeading;
                 lon += forwardDegrees * sinHeading + sideDegrees * cosHeading;
 
-                // If the navigator has panned over either pole, compensate by adjusting the longitude and heading to move
-                // the navigator to the appropriate spot on the other side of the pole.
+                // If the camera has panned over either pole, compensate by adjusting the longitude and heading to move
+                // the camera to the appropriate spot on the other side of the pole.
                 if (lat < -90 || lat > 90) {
-                    this.camera.latitude = Location.normalizeLatitude(lat);
-                    this.camera.longitude = Location.normalizeLongitude(lon + 180);
+                    camera.position.latitude = Location.normalizeLatitude(lat);
+                    camera.position.longitude = Location.normalizeLongitude(lon + 180);
                 } else if (lon < -180 || lon > 180) {
-                    this.camera.latitude = lat;
-                    this.camera.longitude = Location.normalizeLongitude(lon);
+                    camera.position.latitude = lat;
+                    camera.position.longitude = Location.normalizeLongitude(lon);
                 } else {
-                    this.camera.latitude = lat;
-                    this.camera.longitude = lon;
+                    camera.position.latitude = lat;
+                    camera.position.longitude = lon;
                 }
-                //this.camera.heading = WWMath.normalizeAngle360(heading + sideDegrees * 1000);
+                //camera.heading = WWMath.normalizeAngle360(heading + sideDegrees * 1000);
 
-                this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
                 this.wwd.requestRedraw();
             } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
                 this.gestureDidEnd();
@@ -140,12 +135,12 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 this.gestureDidBegin();
             } else if (state == WorldWind.CHANGED) {
                 if (scale != 0) {
-                    // Apply the change in scale to the navigator, relative to when the gesture began.
+                    // Apply the change in scale to the camera, relative to when the gesture began.
                     scale = ((scale - 1) * 0.1f) + 1; // dampen the scale factor
-                    this.camera.altitude = this.camera.altitude * scale;
-                    this.applyLimits(this.camera);
+                    Camera camera = this.getWorldWindow().getCamera();
+                    camera.position.altitude = camera.position.altitude * scale;
+                    this.applyLimits(camera);
 
-                    this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
                     this.wwd.requestRedraw();
                 }
             } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
@@ -163,12 +158,12 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 this.lastRotation = 0;
             } else if (state == WorldWind.CHANGED) {
 
-                // Apply the change in rotation to the navigator, relative to the navigator's current values.
+                // Apply the change in rotation to the camera, relative to the camera's current values.
                 double headingDegrees = this.lastRotation - rotation;
-                this.camera.heading = WWMath.normalizeAngle360(this.camera.heading + headingDegrees);
+                Camera camera = this.getWorldWindow().getCamera();
+                camera.heading = WWMath.normalizeAngle360(camera.heading + headingDegrees);
                 this.lastRotation = rotation;
 
-                this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
                 this.wwd.requestRedraw();
             } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
                 this.gestureDidEnd();
@@ -185,15 +180,15 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 this.gestureDidBegin();
                 this.lastRotation = 0;
             } else if (state == WorldWind.CHANGED) {
-                // Apply the change in tilt to the navigator, relative to when the gesture began.
+                // Apply the change in tilt to the camera, relative to when the gesture began.
                 double headingDegrees = 180 * dx / this.wwd.getWidth();
                 double tiltDegrees = -180 * dy / this.wwd.getHeight();
 
-                this.camera.heading = WWMath.normalizeAngle360(this.beginCamera.heading + headingDegrees);
-                this.camera.tilt = this.beginCamera.tilt + tiltDegrees;
+                Camera camera = this.getWorldWindow().getCamera();
+                camera.heading = WWMath.normalizeAngle360(this.beginHeading + headingDegrees);
+                camera.tilt = this.beginTilt + tiltDegrees;
                 this.applyLimits(camera);
 
-                this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
                 this.wwd.requestRedraw();
             } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
                 this.gestureDidEnd();
@@ -203,8 +198,9 @@ public class CameraControlFragment extends BasicGlobeFragment {
         @Override
         protected void gestureDidBegin() {
             if (this.activeGestures++ == 0) {
-                this.wwd.getNavigator().getAsCamera(this.wwd.getGlobe(), this.beginCamera);
-                this.camera.set(this.beginCamera);
+                Camera camera = this.getWorldWindow().getCamera();
+                this.beginHeading = camera.heading;
+                this.beginTilt = camera.tilt;
             }
         }
 
@@ -213,11 +209,11 @@ public class CameraControlFragment extends BasicGlobeFragment {
 
             double minAltitude = 100;
             double maxAltitude = distanceToExtents;
-            camera.altitude = WWMath.clamp(camera.altitude, minAltitude, maxAltitude);
+            camera.position.altitude = WWMath.clamp(camera.position.altitude, minAltitude, maxAltitude);
 
             // Limit the tilt to between nadir and the horizon (roughly)
-            double r = wwd.getGlobe().getRadiusAt(camera.latitude, camera.latitude);
-            double maxTilt = Math.toDegrees(Math.asin(r / (r + camera.altitude)));
+            double r = wwd.getGlobe().getRadiusAt(camera.position.latitude, camera.position.latitude);
+            double maxTilt = Math.toDegrees(Math.asin(r / (r + camera.position.altitude)));
             double minTilt = 0;
             camera.tilt = WWMath.clamp(camera.tilt, minTilt, maxTilt);
         }

--- a/worldwind-tutorials/src/main/assets/camera_view_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/camera_view_tutorial.html
@@ -27,12 +27,10 @@
 <h3>CameraViewFragment.java</h3>
 <p>
     The CameraViewFragment class extends the BasicGlobeFragment and overrides the createWorldWindow method.
-    Here we position the Navigator's camera at an aircraft's location and point the camera at a nearby airport.
+    Here we position the camera at an aircraft's location and point the camera at a nearby airport.
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class CameraViewFragment extends BasicGlobeFragment {
 
     /**
@@ -55,12 +53,8 @@ public class CameraViewFragment extends BasicGlobeFragment {
         double distance = distanceRadians * globe.getRadiusAt(aircraft.latitude, aircraft.longitude);
         double tilt = Math.toDegrees(Math.atan(distance / aircraft.altitude));
 
-        // Create the new camera view
-        Camera camera = new Camera();
-        camera.set(aircraft.latitude, aircraft.longitude, aircraft.altitude, WorldWind.ABSOLUTE, heading, tilt, 0); // No roll
-
         // Apply the view
-        wwd.getNavigator().setAsCamera(globe, camera);
+        wwd.getCamera().set(aircraft.latitude, aircraft.longitude, aircraft.altitude, WorldWind.ABSOLUTE, heading, tilt, 0); // No roll
 
         // This works too!  Using the fluid api to manipulate the Navigator's camera:
 //        wwd.getNavigator()

--- a/worldwind-tutorials/src/main/assets/geopackage_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/geopackage_tutorial.html
@@ -30,8 +30,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class GeoPackageFragment extends BasicGlobeFragment {
 
     /**
@@ -62,9 +60,7 @@ public class GeoPackageFragment extends BasicGlobeFragment {
                     // Add the finished GeoPackage layer to the WorldWindow.
                     getWorldWindow().getLayers().addLayer(layer);
                     // Place the viewer directly over the GeoPackage image.
-                    getWorldWindow().getNavigator().setLatitude(36.8139677556754);
-                    getWorldWindow().getNavigator().setLongitude(-76.03260320181615);
-                    getWorldWindow().getNavigator().setAltitude(20e3);
+                    getWorldWindow().getCamera().position.set(36.8139677556754, -76.03260320181615, 20e3);
                     Log.i("gov.nasa.worldwind", "GeoPackage layer creation succeeded");
                 }
 

--- a/worldwind-tutorials/src/main/assets/labels_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/labels_tutorial.html
@@ -39,8 +39,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class LabelsFragment extends BasicGlobeFragment {
 
     /**
@@ -96,9 +94,7 @@ public class LabelsFragment extends BasicGlobeFragment {
         layer.addRenderable(label);
 
         // Place the viewer directly over the tutorial labels.
-        wwd.getNavigator().setLatitude(38.89);
-        wwd.getNavigator().setLongitude(-77.023611);
-        wwd.getNavigator().setAltitude(10e3);
+        wwd.getCamera().position.set(38.89, -77.023611, 10e3);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/assets/look_at_view_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/look_at_view_tutorial.html
@@ -26,12 +26,10 @@
 <h3>LookAtViewFragment.java</h3>
 <p>
     The LookAtViewFragment class extends the BasicGlobeFragment and overrides the createWorldWindow method.
-    Here we position the Navigator's camera at an aircraft's location and point the camera at a nearby airport.
+    Here we position the camera at an aircraft's location and point the camera at a nearby airport.
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class LookAtViewFragment extends BasicGlobeFragment {
 
     /**
@@ -60,7 +58,7 @@ public class LookAtViewFragment extends BasicGlobeFragment {
         // Apply the new view
         LookAt lookAt = new LookAt();
         lookAt.set(airport.latitude, airport.longitude, airport.altitude, WorldWind.ABSOLUTE, range, heading, tilt, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(globe, lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/assets/navigator_events_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/navigator_events_tutorial.html
@@ -30,8 +30,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class NavigatorEventFragment extends BasicGlobeFragment {
 
     // UI elements
@@ -45,10 +43,8 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
 
     protected ViewGroup overlay;
 
-    // Use pre-allocated navigator state objects to avoid per-event memory allocations
+    // Use pre-allocated lookAt state object to avoid per-event memory allocations
     private LookAt lookAt = new LookAt();
-
-    private Camera camera = new Camera();
 
     // Track the navigation event time so the overlay refresh rate can be throttled
     private long lastEventTime;
@@ -90,12 +86,11 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
                 // and also it is moving but at an (arbitrary) maximum refresh rate of 20 Hz.
                 if (eventAction == WorldWind.NAVIGATOR_STOPPED || elapsedTime > 50) {
 
-                    // Get the current navigator state to apply to the overlays
-                    event.getNavigator().getAsLookAt(wwd.getGlobe(), lookAt);
-                    event.getNavigator().getAsCamera(wwd.getGlobe(), camera);
+                    // Get the current camera state to apply to the overlays
+                    event.getCamera().getAsLookAt(lookAt);
 
                     // Update the overlays
-                    updateOverlayContents(lookAt, camera);
+                    updateOverlayContents(lookAt, event.getCamera());
                     updateOverlayColor(eventAction);
 
                     lastEventTime = currentTime;
@@ -140,15 +135,15 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
     }
 
     /**
-     * Displays navigator state information in the status overlay views.
+     * Displays camera state information in the status overlay views.
      *
-     * @param lookAt Where the navigator is looking
+     * @param lookAt Where the camera is looking
      * @param camera Where the camera is positioned
      */
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {
-        latView.setText(formatLatitude(lookAt.latitude));
-        lonView.setText(formatLongitude(lookAt.longitude));
-        altView.setText(formatAltitude(camera.altitude));
+        latView.setText(formatLatitude(lookAt.position.latitude));
+        lonView.setText(formatLongitude(lookAt.position.longitude));
+        altView.setText(formatAltitude(camera.position.altitude));
     }
 
     /**

--- a/worldwind-tutorials/src/main/assets/placemarks_picking_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/placemarks_picking_tutorial.html
@@ -48,7 +48,7 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
         WorldWindow wwd = super.createWorldWindow();
 
         // Override the WorldWindow's built-in navigation behavior by adding picking support.
-        wwd.setWorldWindowController(new PickNavigateController());
+        wwd.setWorldWindowController(new PickNavigateController(wwd));
 
         // Add a layer for placemarks to the WorldWindow
         RenderableLayer layer = new RenderableLayer("Placemarks");
@@ -121,6 +121,10 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
                 return false;
             }
         });
+
+        public PickNavigateController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the pick handler or the native WorldWind navigation handlers.

--- a/worldwind-tutorials/src/main/assets/placemarks_picking_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/placemarks_picking_tutorial.html
@@ -31,8 +31,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class PlacemarksPickingFragment extends BasicGlobeFragment {
 
     private static final double NORMAL_IMAGE_SCALE = 3.0;
@@ -64,7 +62,7 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
 
         // Position the viewer to look near the airports
         LookAt lookAt = new LookAt().set(34.15, -119.15, 0, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(wwd.getGlobe(), lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/assets/placemarks_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/placemarks_tutorial.html
@@ -29,8 +29,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class PlacemarksFragment extends BasicGlobeFragment {
 
     /**
@@ -92,7 +90,7 @@ public class PlacemarksFragment extends BasicGlobeFragment {
         Position pos = airport.getPosition();
         LookAt lookAt = new LookAt().set(pos.latitude, pos.longitude, pos.altitude, WorldWind.ABSOLUTE,
             1e5 /*range*/, 0 /*heading*/, 80 /*tilt*/, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(wwd.getGlobe(), lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/assets/surface_image_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/surface_image_tutorial.html
@@ -34,8 +34,6 @@
 </p>
 <div style="border-top: 1px solid black; border-bottom: 1px solid black;">
     <textarea id="java-code">
-package gov.nasa.worldwindx;
-...
 public class SurfaceImageFragment extends BasicGlobeFragment {
 
     /**
@@ -52,6 +50,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
         SurfaceImage surfaceImageResource = new SurfaceImage(sector, ImageSource.fromResource(resourceId));
 
         // Configure a Surface Image to display a remote image showing Mount Etna erupting on July 13th, 2001.
+        // TODO sector constructor from North, South, East, West coordinates
         sector = new Sector(37.46543388598137, 14.60128369746704, 0.45360804083528, 0.75704283995502);
         String urlString = "https://worldwind.arc.nasa.gov/android/tutorials/data/etna.jpg";
         SurfaceImage surfaceImageUrl = new SurfaceImage(sector, ImageSource.fromUrl(urlString));
@@ -63,9 +62,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
         wwd.getLayers().addLayer(layer);
 
         // Position the viewer so that the Surface Images are visible when the activity is created.
-        wwd.getNavigator().setLatitude(37.46543388598137);
-        wwd.getNavigator().setLongitude(14.97980511744455);
-        wwd.getNavigator().setAltitude(4.0e5);
+        wwd.getCamera().position.set(37.46543388598137, 14.97980511744455, 4.0e5);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraControlFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraControlFragment.java
@@ -66,9 +66,9 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 this.lastY = 0;
             } else if (state == WorldWind.CHANGED) {
                 // Get the navigator's current position.
-                double lat = this.camera.latitude;
-                double lon = this.camera.longitude;
-                double alt = this.camera.altitude;
+                double lat = this.camera.position.latitude;
+                double lon = this.camera.position.longitude;
+                double alt = this.camera.position.altitude;
 
                 // Convert the translation from screen coordinates to degrees. Use the navigator's range as a metric for
                 // converting screen pixels to meters, and use the globe's radius for converting from meters to arc degrees.
@@ -93,14 +93,14 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 // If the navigator has panned over either pole, compensate by adjusting the longitude and heading to move
                 // the navigator to the appropriate spot on the other side of the pole.
                 if (lat < -90 || lat > 90) {
-                    this.camera.latitude = Location.normalizeLatitude(lat);
-                    this.camera.longitude = Location.normalizeLongitude(lon + 180);
+                    this.camera.position.latitude = Location.normalizeLatitude(lat);
+                    this.camera.position.longitude = Location.normalizeLongitude(lon + 180);
                 } else if (lon < -180 || lon > 180) {
-                    this.camera.latitude = lat;
-                    this.camera.longitude = Location.normalizeLongitude(lon);
+                    this.camera.position.latitude = lat;
+                    this.camera.position.longitude = Location.normalizeLongitude(lon);
                 } else {
-                    this.camera.latitude = lat;
-                    this.camera.longitude = lon;
+                    this.camera.position.latitude = lat;
+                    this.camera.position.longitude = lon;
                 }
                 //this.camera.heading = WWMath.normalizeAngle360(heading + sideDegrees * 1000);
 
@@ -122,7 +122,7 @@ public class CameraControlFragment extends BasicGlobeFragment {
                 if (scale != 0) {
                     // Apply the change in scale to the navigator, relative to when the gesture began.
                     scale = ((scale - 1) * 0.1f) + 1; // dampen the scale factor
-                    this.camera.altitude = this.camera.altitude * scale;
+                    this.camera.position.altitude = this.camera.position.altitude * scale;
                     this.applyLimits(this.camera);
 
                     this.wwd.getNavigator().setAsCamera(this.wwd.getGlobe(), this.camera);
@@ -193,11 +193,11 @@ public class CameraControlFragment extends BasicGlobeFragment {
 
             double minAltitude = 100;
             double maxAltitude = distanceToExtents;
-            camera.altitude = WWMath.clamp(camera.altitude, minAltitude, maxAltitude);
+            camera.position.altitude = WWMath.clamp(camera.position.altitude, minAltitude, maxAltitude);
 
             // Limit the tilt to between nadir and the horizon (roughly)
-            double r = wwd.getGlobe().getRadiusAt(camera.latitude, camera.latitude);
-            double maxTilt = Math.toDegrees(Math.asin(r / (r + camera.altitude)));
+            double r = wwd.getGlobe().getRadiusAt(camera.position.latitude, camera.position.latitude);
+            double maxTilt = Math.toDegrees(Math.asin(r / (r + camera.position.altitude)));
             double minTilt = 0;
             camera.tilt = WWMath.clamp(camera.tilt, minTilt, maxTilt);
         }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraControlFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraControlFragment.java
@@ -26,7 +26,7 @@ public class CameraControlFragment extends BasicGlobeFragment {
         WorldWindow wwd = super.createWorldWindow();
 
         // Override the default "look at" gesture behavior with a camera centric gesture controller
-        wwd.setWorldWindowController(new CameraController());
+        wwd.setWorldWindowController(new CameraController(wwd));
 
         // Apply camera position above KOXR airport, Oxnard, CA
         wwd.getCamera().set(34.2, -119.2,
@@ -47,6 +47,10 @@ public class CameraControlFragment extends BasicGlobeFragment {
         protected double beginHeading;
 
         protected double beginTilt;
+
+        public CameraController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         @Override
         protected void handlePan(GestureRecognizer recognizer) {

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraViewFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/CameraViewFragment.java
@@ -33,12 +33,8 @@ public class CameraViewFragment extends BasicGlobeFragment {
         double distance = distanceRadians * globe.getRadiusAt(aircraft.latitude, aircraft.longitude);
         double tilt = Math.toDegrees(Math.atan(distance / aircraft.altitude));
 
-        // Create the new camera view
-        Camera camera = new Camera();
-        camera.set(aircraft.latitude, aircraft.longitude, aircraft.altitude, WorldWind.ABSOLUTE, heading, tilt, 0); // No roll
-
         // Apply the view
-        wwd.getNavigator().setAsCamera(globe, camera);
+        wwd.getCamera().set(aircraft.latitude, aircraft.longitude, aircraft.altitude, WorldWind.ABSOLUTE, heading, tilt, 0); // No roll
 
         // This works too!  Using the fluid api to manipulate the Navigator's camera:
 //        wwd.getNavigator()

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/GeoPackageFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/GeoPackageFragment.java
@@ -43,9 +43,7 @@ public class GeoPackageFragment extends BasicGlobeFragment {
                     // Add the finished GeoPackage layer to the WorldWindow.
                     getWorldWindow().getLayers().addLayer(layer);
                     // Place the viewer directly over the GeoPackage image.
-                    getWorldWindow().getNavigator().setLatitude(36.8139677556754);
-                    getWorldWindow().getNavigator().setLongitude(-76.03260320181615);
-                    getWorldWindow().getNavigator().setAltitude(20e3);
+                    getWorldWindow().getCamera().position.set(36.8139677556754, -76.03260320181615, 20e3);
                     Log.i("gov.nasa.worldwind", "GeoPackage layer creation succeeded");
                 }
 

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/LabelsFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/LabelsFragment.java
@@ -71,9 +71,7 @@ public class LabelsFragment extends BasicGlobeFragment {
         layer.addRenderable(label);
 
         // Place the viewer directly over the tutorial labels.
-        wwd.getNavigator().setLatitude(38.89);
-        wwd.getNavigator().setLongitude(-77.023611);
-        wwd.getNavigator().setAltitude(10e3);
+        wwd.getCamera().position.set(38.89, -77.023611, 10e3);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/LookAtViewFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/LookAtViewFragment.java
@@ -39,7 +39,7 @@ public class LookAtViewFragment extends BasicGlobeFragment {
         // Apply the new view
         LookAt lookAt = new LookAt();
         lookAt.set(airport.latitude, airport.longitude, airport.altitude, WorldWind.ABSOLUTE, range, heading, tilt, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(globe, lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/NavigatorEventFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/NavigatorEventFragment.java
@@ -36,10 +36,8 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
 
     protected ViewGroup overlay;
 
-    // Use pre-allocated navigator state objects to avoid per-event memory allocations
+    // Use pre-allocated lookAt state object to avoid per-event memory allocations
     private LookAt lookAt = new LookAt();
-
-    private Camera camera = new Camera();
 
     // Track the navigation event time so the overlay refresh rate can be throttled
     private long lastEventTime;
@@ -81,12 +79,11 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
                 // and also it is moving but at an (arbitrary) maximum refresh rate of 20 Hz.
                 if (eventAction == WorldWind.NAVIGATOR_STOPPED || elapsedTime > 50) {
 
-                    // Get the current navigator state to apply to the overlays
-                    event.getNavigator().getAsLookAt(wwd.getGlobe(), lookAt);
-                    event.getNavigator().getAsCamera(wwd.getGlobe(), camera);
+                    // Get the current camera state to apply to the overlays
+                    event.getCamera().getAsLookAt(lookAt);
 
                     // Update the overlays
-                    updateOverlayContents(lookAt, camera);
+                    updateOverlayContents(lookAt, event.getCamera());
                     updateOverlayColor(eventAction);
 
                     lastEventTime = currentTime;
@@ -131,9 +128,9 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
     }
 
     /**
-     * Displays navigator state information in the status overlay views.
+     * Displays camera state information in the status overlay views.
      *
-     * @param lookAt Where the navigator is looking
+     * @param lookAt Where the camera is looking
      * @param camera Where the camera is positioned
      */
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/NavigatorEventFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/NavigatorEventFragment.java
@@ -137,9 +137,9 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
      * @param camera Where the camera is positioned
      */
     protected void updateOverlayContents(LookAt lookAt, Camera camera) {
-        latView.setText(formatLatitude(lookAt.latitude));
-        lonView.setText(formatLongitude(lookAt.longitude));
-        altView.setText(formatAltitude(camera.altitude));
+        latView.setText(formatLatitude(lookAt.position.latitude));
+        lonView.setText(formatLongitude(lookAt.position.longitude));
+        altView.setText(formatAltitude(camera.position.altitude));
     }
 
     /**

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/OmnidirectionalSightlineFragment.java
@@ -69,6 +69,6 @@ public class OmnidirectionalSightlineFragment extends BasicGlobeFragment {
 
     protected void positionView(WorldWindow wwd) {
         LookAt lookAt = new LookAt().set(46.230, -122.190, 500, WorldWind.ABSOLUTE, 1.5e4 /*range*/, 45.0 /*heading*/, 70.0 /*tilt*/, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(this.getWorldWindow().getGlobe(), lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
     }
 }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksFragment.java
@@ -80,7 +80,7 @@ public class PlacemarksFragment extends BasicGlobeFragment {
         Position pos = airport.getPosition();
         LookAt lookAt = new LookAt().set(pos.latitude, pos.longitude, pos.altitude, WorldWind.ABSOLUTE,
             1e5 /*range*/, 0 /*heading*/, 80 /*tilt*/, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(wwd.getGlobe(), lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksPickingFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksPickingFragment.java
@@ -53,7 +53,7 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
 
         // Position the viewer to look near the airports
         LookAt lookAt = new LookAt().set(34.15, -119.15, 0, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-        wwd.getNavigator().setAsLookAt(wwd.getGlobe(), lookAt);
+        wwd.getCamera().setFromLookAt(lookAt);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksPickingFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/PlacemarksPickingFragment.java
@@ -39,7 +39,7 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
         WorldWindow wwd = super.createWorldWindow();
 
         // Override the WorldWindow's built-in navigation behavior by adding picking support.
-        wwd.setWorldWindowController(new PickNavigateController());
+        wwd.setWorldWindowController(new PickNavigateController(wwd));
 
         // Add a layer for placemarks to the WorldWindow
         RenderableLayer layer = new RenderableLayer("Placemarks");
@@ -112,6 +112,10 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
                 return false;
             }
         });
+
+        public PickNavigateController(WorldWindow wwd) {
+            super(wwd);
+        }
 
         /**
          * Delegates events to the pick handler or the native WorldWind navigation handlers.

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/SurfaceImageFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/SurfaceImageFragment.java
@@ -39,9 +39,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
         wwd.getLayers().addLayer(layer);
 
         // Position the viewer so that the Surface Images are visible when the activity is created.
-        wwd.getNavigator().setLatitude(37.46543388598137);
-        wwd.getNavigator().setLongitude(14.97980511744455);
-        wwd.getNavigator().setAltitude(4.0e5);
+        wwd.getCamera().position.set(37.46543388598137, 14.97980511744455, 4.0e5);
 
         return wwd;
     }

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/WcsElevationFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/WcsElevationFragment.java
@@ -67,9 +67,6 @@ public class WcsElevationFragment extends BasicGlobeFragment {
         double tilt = Math.toDegrees(Math.atan(distance / eye.altitude));
 
         // Apply the new view
-        Camera camera = new Camera();
-        camera.set(eye.latitude, eye.longitude, eye.altitude, WorldWind.ABSOLUTE, heading, tilt, 0.0 /*roll*/);
-
-        wwd.getNavigator().setAsCamera(globe, camera);
+        wwd.getCamera().set(eye.latitude, eye.longitude, eye.altitude, WorldWind.ABSOLUTE, heading, tilt, 0.0 /*roll*/);
     }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -203,7 +203,7 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
 
     protected void handleTilt(GestureRecognizer recognizer) {
         int state = recognizer.getState();
-        float dx = recognizer.getTranslationX();
+        //float dx = recognizer.getTranslationX();
         float dy = recognizer.getTranslationY();
 
         if (state == WorldWind.BEGAN) {
@@ -211,9 +211,10 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.lastRotation = 0;
         } else if (state == WorldWind.CHANGED) {
             // Apply the change in tilt to the camera, relative to when the gesture began.
-            double headingDegrees = 180 * dx / this.wwd.getWidth();
+            //double headingDegrees = 180 * dx / this.wwd.getWidth();
             double tiltDegrees = -180 * dy / this.wwd.getHeight();
-            this.lookAt.heading = WWMath.normalizeAngle360(this.beginLookAt.heading + headingDegrees);
+            // Do not change heading on tilt
+            //this.lookAt.heading = WWMath.normalizeAngle360(this.beginLookAt.heading + headingDegrees);
             this.lookAt.tilt = this.beginLookAt.tilt + tiltDegrees;
             this.applyLimits(this.lookAt);
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -105,8 +105,8 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.lastY = 0;
         } else if (state == WorldWind.CHANGED) {
             // Get the navigator's current position.
-            double lat = this.lookAt.latitude;
-            double lon = this.lookAt.longitude;
+            double lat = this.lookAt.position.latitude;
+            double lon = this.lookAt.position.longitude;
             double rng = this.lookAt.range;
 
             // Convert the translation from screen coordinates to degrees. Use the navigator's range as a metric for
@@ -132,15 +132,15 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             // If the navigator has panned over either pole, compensate by adjusting the longitude and heading to move
             // the navigator to the appropriate spot on the other side of the pole.
             if (lat < -90 || lat > 90) {
-                this.lookAt.latitude = Location.normalizeLatitude(lat);
-                this.lookAt.longitude = Location.normalizeLongitude(lon + 180);
+                this.lookAt.position.latitude = Location.normalizeLatitude(lat);
+                this.lookAt.position.longitude = Location.normalizeLongitude(lon + 180);
                 this.lookAt.heading = WWMath.normalizeAngle360(heading + 180);
             } else if (lon < -180 || lon > 180) {
-                this.lookAt.latitude = lat;
-                this.lookAt.longitude = Location.normalizeLongitude(lon);
+                this.lookAt.position.latitude = lat;
+                this.lookAt.position.longitude = Location.normalizeLongitude(lon);
             } else {
-                this.lookAt.latitude = lat;
-                this.lookAt.longitude = lon;
+                this.lookAt.position.latitude = lat;
+                this.lookAt.position.longitude = lon;
             }
 
             this.wwd.getNavigator().setAsLookAt(this.wwd.getGlobe(), this.lookAt);

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -22,6 +22,8 @@ import gov.nasa.worldwind.util.WWMath;
 
 public class BasicWorldWindowController implements WorldWindowController, GestureListener {
 
+    private static final float ZOOM_FACTOR = 1.5f;
+
     protected WorldWindow wwd;
 
     protected float lastX;
@@ -68,6 +70,36 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
         ((RotationRecognizer) this.rotationRecognizer).setInterpretAngle(20f);
         ((PanRecognizer) this.tiltRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.tilt_interpret_distance));
         ((MousePanRecognizer) this.mouseTiltRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.tilt_interpret_distance));
+    }
+
+    public void resetOrientation(boolean headingOnly) {
+        this.gestureDidBegin();
+        this.lookAt.heading = 0;
+        if(!headingOnly) {
+            this.lookAt.tilt = 0;
+            this.lookAt.roll = 0;
+        }
+        this.wwd.getCamera().setFromLookAt(this.lookAt);
+        this.wwd.requestRedraw();
+        this.gestureDidEnd();
+    }
+
+    public void zoomIn() {
+        this.gestureDidBegin();
+        this.lookAt.range /= ZOOM_FACTOR;
+        this.applyLimits(lookAt);
+        this.wwd.getCamera().setFromLookAt(this.lookAt);
+        this.wwd.requestRedraw();
+        this.gestureDidEnd();
+    }
+
+    public void zoomOut() {
+        this.gestureDidBegin();
+        this.lookAt.range *= ZOOM_FACTOR;
+        this.applyLimits(lookAt);
+        this.wwd.getCamera().setFromLookAt(this.lookAt);
+        this.wwd.requestRedraw();
+        this.gestureDidEnd();
     }
 
     @Override

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -104,12 +104,12 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.lastX = 0;
             this.lastY = 0;
         } else if (state == WorldWind.CHANGED) {
-            // Get the navigator's current position.
+            // Get observation point position.
             double lat = this.lookAt.position.latitude;
             double lon = this.lookAt.position.longitude;
             double rng = this.lookAt.range;
 
-            // Convert the translation from screen coordinates to degrees. Use the navigator's range as a metric for
+            // Convert the translation from screen coordinates to degrees. Use observation point range as a metric for
             // converting screen pixels to meters, and use the globe's radius for converting from meters to arc degrees.
             double metersPerPixel = this.wwd.pixelSizeAtDistance(rng);
             double forwardMeters = (dy - this.lastY) * metersPerPixel;
@@ -121,7 +121,7 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             double forwardDegrees = Math.toDegrees(forwardMeters / globeRadius);
             double sideDegrees = Math.toDegrees(sideMeters / globeRadius);
 
-            // Adjust the change in latitude and longitude based on the navigator's heading.
+            // Adjust the change in latitude and longitude based on observation point heading.
             double heading = this.lookAt.heading;
             double headingRadians = Math.toRadians(heading);
             double sinHeading = Math.sin(headingRadians);
@@ -129,8 +129,8 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             lat += forwardDegrees * cosHeading - sideDegrees * sinHeading;
             lon += forwardDegrees * sinHeading + sideDegrees * cosHeading;
 
-            // If the navigator has panned over either pole, compensate by adjusting the longitude and heading to move
-            // the navigator to the appropriate spot on the other side of the pole.
+            // If the camera has panned over either pole, compensate by adjusting the longitude and heading to move
+            // the camera to the appropriate spot on the other side of the pole.
             if (lat < -90 || lat > 90) {
                 this.lookAt.position.latitude = Location.normalizeLatitude(lat);
                 this.lookAt.position.longitude = Location.normalizeLongitude(lon + 180);
@@ -143,7 +143,7 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
                 this.lookAt.position.longitude = lon;
             }
 
-            this.wwd.getNavigator().setAsLookAt(this.wwd.getGlobe(), this.lookAt);
+            this.wwd.getCamera().setFromLookAt(this.lookAt);
             this.wwd.requestRedraw();
         } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
             this.gestureDidEnd();
@@ -158,11 +158,11 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.gestureDidBegin();
         } else if (state == WorldWind.CHANGED) {
             if (scale != 0) {
-                // Apply the change in scale to the navigator, relative to when the gesture began.
+                // Apply the change in range to observation point, relative to when the gesture began.
                 this.lookAt.range = this.beginLookAt.range / scale;
                 this.applyLimits(this.lookAt);
 
-                this.wwd.getNavigator().setAsLookAt(this.wwd.getGlobe(), this.lookAt);
+                this.wwd.getCamera().setFromLookAt(this.lookAt);
                 this.wwd.requestRedraw();
             }
         } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
@@ -178,12 +178,12 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.gestureDidBegin();
             this.lastRotation = 0;
         } else if (state == WorldWind.CHANGED) {
-            // Apply the change in rotation to the navigator, relative to the navigator's current values.
+            // Apply the change in rotation to the camera, relative to the camera's current values.
             double headingDegrees = this.lastRotation - rotation;
             this.lookAt.heading = WWMath.normalizeAngle360(this.lookAt.heading + headingDegrees);
             this.lastRotation = rotation;
 
-            this.wwd.getNavigator().setAsLookAt(this.wwd.getGlobe(), this.lookAt);
+            this.wwd.getCamera().setFromLookAt(this.lookAt);
             this.wwd.requestRedraw();
         } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
             this.gestureDidEnd();
@@ -199,14 +199,14 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.gestureDidBegin();
             this.lastRotation = 0;
         } else if (state == WorldWind.CHANGED) {
-            // Apply the change in tilt to the navigator, relative to when the gesture began.
+            // Apply the change in tilt to the camera, relative to when the gesture began.
             double headingDegrees = 180 * dx / this.wwd.getWidth();
             double tiltDegrees = -180 * dy / this.wwd.getHeight();
             this.lookAt.heading = WWMath.normalizeAngle360(this.beginLookAt.heading + headingDegrees);
             this.lookAt.tilt = this.beginLookAt.tilt + tiltDegrees;
             this.applyLimits(this.lookAt);
 
-            this.wwd.getNavigator().setAsLookAt(this.wwd.getGlobe(), this.lookAt);
+            this.wwd.getCamera().setFromLookAt(this.lookAt);
             this.wwd.requestRedraw();
         } else if (state == WorldWind.ENDED || state == WorldWind.CANCELLED) {
             this.gestureDidEnd();
@@ -229,7 +229,7 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
 
     protected void gestureDidBegin() {
         if (this.activeGestures++ == 0) {
-            this.wwd.getNavigator().getAsLookAt(this.wwd.getGlobe(), this.beginLookAt);
+            this.wwd.getCamera().getAsLookAt(this.beginLookAt);
             this.lookAt.set(this.beginLookAt);
         }
     }

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -49,7 +49,9 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
     protected List<GestureRecognizer> allRecognizers = Arrays.asList(
         this.panRecognizer, this.pinchRecognizer, this.rotationRecognizer, this.tiltRecognizer, this.mouseTiltRecognizer);
 
-    public BasicWorldWindowController() {
+    public BasicWorldWindowController(WorldWindow wwd) {
+        this.wwd = wwd;
+
         this.panRecognizer.addListener(this);
         this.pinchRecognizer.addListener(this);
         this.rotationRecognizer.addListener(this);
@@ -59,15 +61,18 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
         ((PanRecognizer) this.panRecognizer).setMaxNumberOfPointers(1); // Do not pan during tilt
         ((PanRecognizer) this.tiltRecognizer).setMinNumberOfPointers(2); // Use two fingers for tilt gesture
         ((MousePanRecognizer) this.mouseTiltRecognizer).setButtonState(MotionEvent.BUTTON_SECONDARY);
-    }
 
-    public WorldWindow getWorldWindow() {
-        return wwd;
+        // Set interpret distance based on screen density
+        ((PanRecognizer) this.panRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.pan_interpret_distance));
+        ((PinchRecognizer) this.pinchRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.pinch_interpret_distance));
+        ((RotationRecognizer) this.rotationRecognizer).setInterpretAngle(20f);
+        ((PanRecognizer) this.tiltRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.tilt_interpret_distance));
+        ((MousePanRecognizer) this.mouseTiltRecognizer).setInterpretDistance(wwd.getContext().getResources().getDimension(R.dimen.tilt_interpret_distance));
     }
 
     @Override
-    public void setWorldWindow(WorldWindow wwd) {
-        this.wwd = wwd;
+    public WorldWindow getWorldWindow() {
+        return wwd;
     }
 
     @Override

--- a/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/BasicWorldWindowController.java
@@ -56,8 +56,8 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
         this.tiltRecognizer.addListener(this);
         this.mouseTiltRecognizer.addListener(this);
 
-        ((PanRecognizer) this.panRecognizer).setMaxNumberOfPointers(2);
-        ((PanRecognizer) this.tiltRecognizer).setMinNumberOfPointers(3); // TODO support for two-finger tilt gestures
+        ((PanRecognizer) this.panRecognizer).setMaxNumberOfPointers(1); // Do not pan during tilt
+        ((PanRecognizer) this.tiltRecognizer).setMinNumberOfPointers(2); // Use two fingers for tilt gesture
         ((MousePanRecognizer) this.mouseTiltRecognizer).setButtonState(MotionEvent.BUTTON_SECONDARY);
     }
 
@@ -76,6 +76,12 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
 
         for (int idx = 0, len = this.allRecognizers.size(); idx < len; idx++) {
             handled |= this.allRecognizers.get(idx).onTouchEvent(event); // use or-assignment to indicate if any recognizer handled the event
+        }
+
+        // Handle dependent gestures lock
+        if(handled) {
+            tiltRecognizer.setEnabled(!isInProcess(rotationRecognizer) || !rotationRecognizer.isEnabled());
+            rotationRecognizer.setEnabled(!isInProcess(tiltRecognizer) || !tiltRecognizer.isEnabled());
         }
 
         return handled;
@@ -239,4 +245,9 @@ public class BasicWorldWindowController implements WorldWindowController, Gestur
             this.activeGestures--;
         }
     }
+
+    private boolean isInProcess(GestureRecognizer recognizer) {
+        return recognizer.getState() == WorldWind.BEGAN || recognizer.getState() == WorldWind.CHANGED;
+    }
+
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/Navigator.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/Navigator.java
@@ -6,37 +6,13 @@
 package gov.nasa.worldwind;
 
 import gov.nasa.worldwind.geom.Camera;
-import gov.nasa.worldwind.geom.Line;
 import gov.nasa.worldwind.geom.LookAt;
 import gov.nasa.worldwind.geom.Matrix4;
-import gov.nasa.worldwind.geom.Position;
-import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.globe.Globe;
 import gov.nasa.worldwind.util.Logger;
 
+@Deprecated
 public class Navigator {
-
-    private final static double COLLISION_THRESHOLD = 10.0; // 10m above surface
-
-    protected final Position position = new Position();
-
-    protected double heading;
-
-    protected double tilt;
-
-    protected double roll;
-
-    private final Camera scratchCamera = new Camera();
-
-    private final Matrix4 modelview = new Matrix4();
-
-    private final Matrix4 origin = new Matrix4();
-
-    private final Vec3 originPoint = new Vec3();
-
-    private final Position originPos = new Position();
-
-    private final Line forwardRay = new Line();
 
     private final WorldWindow wwd;
 
@@ -50,56 +26,56 @@ public class Navigator {
     }
 
     public double getLatitude() {
-        return this.position.latitude;
+        return this.wwd.getCamera().position.latitude;
     }
 
     public Navigator setLatitude(double latitude) {
-        this.position.latitude = latitude;
+        this.wwd.getCamera().position.latitude = latitude;
         return this;
     }
 
     public double getLongitude() {
-        return this.position.longitude;
+        return this.wwd.getCamera().position.longitude;
     }
 
     public Navigator setLongitude(double longitude) {
-        this.position.longitude = longitude;
+        this.wwd.getCamera().position.longitude = longitude;
         return this;
     }
 
     public double getAltitude() {
-        return this.position.altitude;
+        return this.wwd.getCamera().position.altitude;
     }
 
     public Navigator setAltitude(double altitude) {
-        this.position.altitude = altitude;
+        this.wwd.getCamera().position.altitude = altitude;
         return this;
     }
 
     public double getHeading() {
-        return this.heading;
+        return this.wwd.getCamera().heading;
     }
 
     public Navigator setHeading(double headingDegrees) {
-        this.heading = headingDegrees;
+        this.wwd.getCamera().heading = headingDegrees;
         return this;
     }
 
     public double getTilt() {
-        return this.tilt;
+        return this.wwd.getCamera().tilt;
     }
 
     public Navigator setTilt(double tiltDegrees) {
-        this.tilt = tiltDegrees;
+        this.wwd.getCamera().tilt = tiltDegrees;
         return this;
     }
 
     public double getRoll() {
-        return this.roll;
+        return this.wwd.getCamera().roll;
     }
 
     public Navigator setRoll(double rollDegrees) {
-        this.roll = rollDegrees;
+        this.wwd.getCamera().roll = rollDegrees;
         return this;
     }
 
@@ -114,11 +90,7 @@ public class Navigator {
                 Logger.logMessage(Logger.ERROR, "Navigator", "getAsCamera", "missingResult"));
         }
 
-        result.position.set(this.position);
-        result.altitudeMode = WorldWind.ABSOLUTE;
-        result.heading = this.heading;
-        result.tilt = this.tilt;
-        result.roll = this.roll;
+        result.set(this.wwd.camera);
 
         return result;
     }
@@ -134,10 +106,7 @@ public class Navigator {
                 Logger.logMessage(Logger.ERROR, "Navigator", "setAsCamera", "missingCamera"));
         }
 
-        this.position.set(camera.position); // TODO interpret altitude modes other than absolute
-        this.heading = camera.heading;
-        this.tilt = camera.tilt;
-        this.roll = camera.roll;
+        this.wwd.camera.set(camera);
 
         return this;
     }
@@ -153,8 +122,7 @@ public class Navigator {
                 Logger.logMessage(Logger.ERROR, "Navigator", "getAsLookAt", "missingResult"));
         }
 
-        this.getAsCamera(globe, this.scratchCamera); // get this navigator's properties as a Camera
-        this.cameraToLookAt(globe, this.scratchCamera, result); // convert the Camera to a LookAt
+        this.wwd.getCamera().getAsLookAt(result);
 
         return result;
     }
@@ -170,8 +138,7 @@ public class Navigator {
                 Logger.logMessage(Logger.ERROR, "Navigator", "setAsLookAt", "missingLookAt"));
         }
 
-        this.lookAtToCamera(globe, lookAt, this.scratchCamera); // convert the LookAt to a Camera
-        this.setAsCamera(globe, this.scratchCamera); // set this navigator's properties as a Camera
+        this.wwd.getCamera().setFromLookAt(lookAt);
 
         return this;
     }
@@ -187,109 +154,9 @@ public class Navigator {
                 Logger.logMessage(Logger.ERROR, "Navigator", "getAsViewingMatrix", "missingResult"));
         }
 
-        this.getAsCamera(globe, this.scratchCamera); // get this navigator's properties as a Camera
-        this.cameraToViewingMatrix(globe, this.scratchCamera, result); // convert the Camera to a viewing matrix
+        this.wwd.getCamera().computeViewingTransform(result);
 
         return result;
     }
 
-    protected LookAt cameraToLookAt(Globe globe, Camera camera, LookAt result) {
-        this.cameraToViewingMatrix(globe, camera, this.modelview);
-
-        // Pick terrain located behind the viewport center point
-        PickedObject terrainPickedObject = wwd.pick(wwd.getViewport().width / 2f, wwd.getViewport().height / 2f).terrainPickedObject();
-        if (terrainPickedObject != null) {
-            // Use picked terrain position including approximate rendered altitude
-            this.originPos.set(terrainPickedObject.getTerrainPosition());
-            globe.geographicToCartesian(this.originPos.latitude, this.originPos.longitude, this.originPos.altitude, this.originPoint);
-            globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
-        } else {
-            // Center is outside the globe - use point on horizon
-            this.modelview.extractEyePoint(this.forwardRay.origin);
-            this.modelview.extractForwardVector(this.forwardRay.direction);
-            this.forwardRay.pointAt(globe.horizonDistance(camera.position.altitude), this.originPoint);
-            globe.cartesianToGeographic(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.originPos);
-            globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
-        }
-
-        this.modelview.multiplyByMatrix(this.origin);
-
-        result.position.set(this.originPos);
-        result.range = -this.modelview.m[11];
-        result.heading = this.modelview.extractHeading(camera.roll); // disambiguate heading and roll
-        result.tilt = this.modelview.extractTilt();
-        result.roll = camera.roll; // roll passes straight through
-
-        return result;
-    }
-
-    protected Matrix4 cameraToViewingMatrix(Globe globe, Camera camera, Matrix4 result) {
-        // TODO interpret altitude mode other than absolute
-        // Transform by the local cartesian transform at the camera's position.
-        globe.geographicToCartesianTransform(camera.position.latitude, camera.position.longitude, camera.position.altitude, result);
-
-        // Transform by the heading, tilt and roll.
-        result.multiplyByRotation(0, 0, 1, -camera.heading); // rotate clockwise about the Z axis
-        result.multiplyByRotation(1, 0, 0, camera.tilt); // rotate counter-clockwise about the X axis
-        result.multiplyByRotation(0, 0, 1, camera.roll); // rotate counter-clockwise about the Z axis (again)
-
-        // Make the transform a viewing matrix.
-        result.invertOrthonormal();
-
-        return result;
-    }
-
-    protected Camera lookAtToCamera(Globe globe, LookAt lookAt, Camera result) {
-        this.lookAtToViewingTransform(globe, lookAt, this.modelview);
-        this.modelview.extractEyePoint(this.originPoint);
-
-        globe.cartesianToGeographic(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.originPos);
-        globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
-        this.modelview.multiplyByMatrix(this.origin);
-
-        result.position.set(this.originPos);
-        result.heading = this.modelview.extractHeading(lookAt.roll); // disambiguate heading and roll
-        result.tilt = this.modelview.extractTilt();
-        result.roll = lookAt.roll; // roll passes straight through
-
-        // Check if camera altitude is not under the surface
-        double elevation = globe.getElevationAtLocation(result.position.latitude, result.position.longitude) * wwd.getVerticalExaggeration() + COLLISION_THRESHOLD;
-        if(elevation > result.position.altitude) {
-            // Set camera altitude above the surface
-            result.position.altitude = elevation;
-            // Compute new camera point
-            globe.geographicToCartesian(result.position.latitude, result.position.longitude, result.position.altitude, originPoint);
-            // Compute look at point
-            globe.geographicToCartesian(lookAt.position.latitude, lookAt.position.longitude, lookAt.position.altitude, forwardRay.origin);
-            // Compute normal to globe in look at point
-            globe.geographicToCartesianNormal(lookAt.position.latitude, lookAt.position.longitude, forwardRay.direction);
-            // Calculate tilt angle between new camera point and look at point
-            originPoint.subtract(forwardRay.origin).normalize();
-            double dot = forwardRay.direction.dot(originPoint);
-            if (dot >= -1 || dot <= 1) {
-                result.tilt = Math.toDegrees(Math.acos(dot));
-            }
-        }
-
-        return result;
-    }
-
-    protected Matrix4 lookAtToViewingTransform(Globe globe, LookAt lookAt, Matrix4 result) {
-        // TODO interpret altitude mode other than absolute
-        // Transform by the local cartesian transform at the look-at's position.
-        globe.geographicToCartesianTransform(lookAt.position.latitude, lookAt.position.longitude, lookAt.position.altitude, result);
-
-        // Transform by the heading and tilt.
-        result.multiplyByRotation(0, 0, 1, -lookAt.heading); // rotate clockwise about the Z axis
-        result.multiplyByRotation(1, 0, 0, lookAt.tilt); // rotate counter-clockwise about the X axis
-        result.multiplyByRotation(0, 0, 1, lookAt.roll); // rotate counter-clockwise about the Z axis (again)
-
-        // Transform by the range.
-        result.multiplyByTranslation(0, 0, lookAt.range);
-
-        // Make the transform a viewing matrix.
-        result.invertOrthonormal();
-
-        return result;
-    }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEvent.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEvent.java
@@ -7,6 +7,7 @@ package gov.nasa.worldwind;
 
 import android.view.InputEvent;
 
+import gov.nasa.worldwind.geom.Camera;
 import gov.nasa.worldwind.util.BasicPool;
 import gov.nasa.worldwind.util.Pool;
 
@@ -14,7 +15,7 @@ public class NavigatorEvent {
 
     private static Pool<NavigatorEvent> pool = new BasicPool<>();
 
-    protected Navigator navigator;
+    protected Camera camera;
 
     @WorldWind.NavigatorAction
     protected int action = WorldWind.NAVIGATOR_MOVED;
@@ -24,13 +25,13 @@ public class NavigatorEvent {
     protected NavigatorEvent() {
     }
 
-    public static NavigatorEvent obtain(Navigator navigator, @WorldWind.NavigatorAction int action, InputEvent lastInputEvent) {
+    public static NavigatorEvent obtain(Camera camera, @WorldWind.NavigatorAction int action, InputEvent lastInputEvent) {
         NavigatorEvent instance = pool.acquire();
         if (instance == null) {
             instance = new NavigatorEvent();
         }
 
-        instance.navigator = navigator;
+        instance.camera = camera;
         instance.action = action;
         instance.lastInputEvent = lastInputEvent;
 
@@ -41,14 +42,14 @@ public class NavigatorEvent {
      * Recycle the event, making it available for re-use.
      */
     public void recycle() {
-        this.navigator = null;
+        this.camera = null;
         this.action = WorldWind.NAVIGATOR_MOVED;
         this.lastInputEvent = null;
         pool.release(this);
     }
 
-    public Navigator getNavigator() {
-        return this.navigator;
+    public Camera getCamera() {
+        return this.camera;
     }
 
     @WorldWind.NavigatorAction

--- a/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEventSupport.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/NavigatorEventSupport.java
@@ -158,7 +158,7 @@ public class NavigatorEventSupport {
     }
 
     protected void notifyListeners(int action, InputEvent inputEvent) {
-        NavigatorEvent event = NavigatorEvent.obtain(this.wwd.navigator, action, inputEvent);
+        NavigatorEvent event = NavigatorEvent.obtain(this.wwd.getCamera(), action, inputEvent);
         for (int idx = 0, len = this.listeners.size(); idx < len; idx++) {
             this.listeners.get(idx).onNavigatorEvent(this.wwd, event);
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
@@ -84,7 +84,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
     protected FrameMetrics frameMetrics = new FrameMetrics();
 
-    protected WorldWindowController worldWindowController = new BasicWorldWindowController();
+    protected WorldWindowController worldWindowController = new BasicWorldWindowController(this);
 
     protected RenderResourceCache renderResourceCache;
 
@@ -172,9 +172,6 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         Location initLocation = Location.fromTimeZone(TimeZone.getDefault());
         double initAltitude = this.distanceToViewGlobeExtents() * 1.1; // add 10% to the minimum distance to allow for space around the screen edges
         this.camera.position.set(initLocation.latitude, initLocation.longitude, initAltitude);
-
-        // Initialize the WorldWindow's controller.
-        this.worldWindowController.setWorldWindow(this);
 
         // Initialize the WorldWindow's render resource cache.
         int cacheCapacity = RenderResourceCache.recommendedCapacity();
@@ -362,9 +359,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
                 Logger.logMessage(Logger.ERROR, "WorldWindow", "setWorldWindowController", "missingController"));
         }
 
-        this.worldWindowController.setWorldWindow(null); // detach the old controller
         this.worldWindowController = controller; // switch to the new controller
-        this.worldWindowController.setWorldWindow(this); // attach the new controller
     }
 
     public RenderResourceCache getRenderResourceCache() {

--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
@@ -73,8 +73,9 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
     protected double verticalExaggeration = 1;
 
-    protected double fieldOfView = 45;
+    protected Camera camera = new Camera(this);
 
+    @Deprecated
     protected Navigator navigator = new Navigator(this);
 
     protected NavigatorEventSupport navigatorEvents = new NavigatorEventSupport(this);
@@ -167,12 +168,10 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
      * @param configChooser optional argument for choosing an EGL configuration; may be null
      */
     protected void init(EGLConfigChooser configChooser) {
-        // Initialize the WorldWindow's navigator.
+        // Initialize the WorldWindow's camera.
         Location initLocation = Location.fromTimeZone(TimeZone.getDefault());
         double initAltitude = this.distanceToViewGlobeExtents() * 1.1; // add 10% to the minimum distance to allow for space around the screen edges
-        this.navigator.setLatitude(initLocation.latitude);
-        this.navigator.setLongitude(initLocation.longitude);
-        this.navigator.setAltitude(initAltitude);
+        this.camera.position.set(initLocation.latitude, initLocation.longitude, initAltitude);
 
         // Initialize the WorldWindow's controller.
         this.worldWindowController.setWorldWindow(this);
@@ -282,30 +281,23 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         this.verticalExaggeration = verticalExaggeration;
     }
 
+    public Camera getCamera() {
+        return this.camera;
+    }
+
+    @Deprecated
     public double getFieldOfView() {
-        return this.fieldOfView;
+        return this.camera.getFieldOfView();
     }
 
+    @Deprecated
     public void setFieldOfView(double fovyDegrees) {
-        if (fovyDegrees <= 0 || fovyDegrees >= 180) {
-            throw new IllegalArgumentException(
-                Logger.logMessage(Logger.ERROR, "WorldWindow", "setFieldOfView", "invalidFieldOfView"));
-        }
-
-        this.fieldOfView = fovyDegrees;
+        this.camera.setFieldOfView(fovyDegrees);
     }
 
+    @Deprecated
     public Navigator getNavigator() {
         return this.navigator;
-    }
-
-    public void setNavigator(Navigator navigator) {
-        if (navigator == null) {
-            throw new IllegalArgumentException(
-                Logger.logMessage(Logger.ERROR, "WorldWindow", "setNavigator", "missingNavigator"));
-        }
-
-        this.navigator = navigator;
     }
 
     public void addNavigatorListener(NavigatorListener listener) {
@@ -599,7 +591,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         double sx = x;
         double sy = this.getHeight() - y;
 
-        // Compute the inverse modelview-projection matrix corresponding to the WorldWindow's current Navigator state.
+        // Compute the inverse modelview-projection matrix corresponding to the WorldWindow's current Camera state.
         this.computeViewingTransform(this.scratchProjection, this.scratchModelview);
         this.scratchProjection.multiplyByMatrix(this.scratchModelview).invert();
 
@@ -626,7 +618,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
      * @return the pixel height in meters per pixel
      */
     public double pixelSizeAtDistance(double distance) {
-        double tanfovy_2 = Math.tan(Math.toRadians(this.fieldOfView * 0.5));
+        double tanfovy_2 = Math.tan(Math.toRadians(this.camera.getFieldOfView() * 0.5));
         double frustumHeight = 2 * distance * tanfovy_2;
         return frustumHeight / this.getHeight();
     }
@@ -638,13 +630,13 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
      * @return the distance in meters needed to view the entire globe
      */
     public double distanceToViewGlobeExtents() {
-        double sinfovy_2 = Math.sin(Math.toRadians(this.fieldOfView * 0.5));
+        double sinfovy_2 = Math.sin(Math.toRadians(this.camera.getFieldOfView() * 0.5));
         double radius = this.globe.getEquatorialRadius();
         return radius / sinfovy_2 - radius;
     }
 
     /**
-     * Request that this WorldWindow update its display. Prior changes to this WorldWindow's Navigator, Globe and
+     * Request that this WorldWindow update its display. Prior changes to this WorldWindow's Camera, Globe and
      * Layers (including the contents of layers) are reflected on screen sometime after calling this method. May be
      * called from any thread.
      */
@@ -688,7 +680,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
     /**
      * Requests that this WorldWindow's OpenGL renderer display another frame on the OpenGL thread. Does not cause the
-     * WorldWindow's to display changes in its Navigator, Globe or Layers. Use {@link #requestRedraw()} instead.
+     * WorldWindow's to display changes in its Camera, Globe or Layers. Use {@link #requestRedraw()} instead.
      *
      * @deprecated Use {@link #requestRedraw} instead.
      */
@@ -699,7 +691,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
 
     /**
      * Queues a runnable to be executed on this WorldWindow's OpenGL thread. Must not be used to affect changes to this
-     * WorldWindow's state, including the Navigator, Globe and Layers. See the Android developers guide on <a
+     * WorldWindow's state, including the Camera, Globe and Layers. See the Android developers guide on <a
      * href="http://developer.android.com/training/multiple-threads/communicate-ui.html">Communicating with the UI
      * Thread</a> instead.
      *
@@ -909,9 +901,8 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         this.rc.terrainTessellator = this.tessellator;
         this.rc.layers = this.layers;
         this.rc.verticalExaggeration = this.verticalExaggeration;
-        this.rc.fieldOfView = this.fieldOfView;
-        this.rc.horizonDistance = this.globe.horizonDistance(this.navigator.getAltitude());
-        this.rc.camera = this.navigator.getAsCamera(this.globe, this.rc.camera);
+        this.rc.horizonDistance = this.globe.horizonDistance(this.camera.position.altitude);
+        this.rc.camera = this.camera;
         this.rc.cameraPoint = this.globe.geographicToCartesian(this.rc.camera.position.latitude, this.rc.camera.position.longitude, this.rc.camera.position.altitude, this.rc.cameraPoint);
         this.rc.renderResourceCache = this.renderResourceCache;
         this.rc.renderResourceCache.setResources(this.getContext().getResources());
@@ -920,7 +911,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         // Configure the frame's Cartesian modelview matrix and eye coordinate projection matrix.
         this.computeViewingTransform(frame.projection, frame.modelview);
         frame.viewport.set(this.viewport);
-        frame.infiniteProjection.setToInfiniteProjection(this.viewport.width, this.viewport.height, this.fieldOfView, 1.0);
+        frame.infiniteProjection.setToInfiniteProjection(this.viewport.width, this.viewport.height, this.camera.getFieldOfView(), 1.0);
         frame.infiniteProjection.multiplyByMatrix(frame.modelview);
         this.rc.viewport.set(frame.viewport);
         this.rc.projection.set(frame.projection);
@@ -1037,10 +1028,10 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
     protected void computeViewingTransform(Matrix4 projection, Matrix4 modelview) {
         // Compute the clip plane distances. The near distance is set to a large value that does not clip the globe's
         // surface. The far distance is set to the smallest value that does not clip the atmosphere.
-        // TODO adjust the clip plane distances based on the navigator's orientation - shorter distances when the
+        // TODO adjust the clip plane distances based on the camera's orientation - shorter distances when the
         // TODO horizon is not in view
         // TODO parameterize the object altitude for horizon distance
-        double eyeAltitude = this.navigator.getAltitude();
+        double eyeAltitude = this.camera.position.altitude;
         double eyeHorizon = this.globe.horizonDistance(eyeAltitude);
         double atmosphereHorizon = this.globe.horizonDistance(160000);
 
@@ -1054,9 +1045,9 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         double near = far / (maxDepthValue / (1 - farResolution / far) - maxDepthValue + 1);
 
         // Prevent the near clip plane from intersecting the terrain.
-        double distanceToSurface = this.navigator.getAltitude() - this.globe.getElevationAtLocation(this.navigator.getLatitude(), this.navigator.getLongitude()) * this.getVerticalExaggeration();
+        double distanceToSurface = this.camera.position.altitude - this.globe.getElevationAtLocation(this.camera.position.latitude, this.camera.position.longitude) * this.getVerticalExaggeration();
         if (distanceToSurface > 0) {
-            double tanHalfFov = Math.tan(0.5 * Math.toRadians(this.fieldOfView));
+            double tanHalfFov = Math.tan(0.5 * Math.toRadians(this.camera.getFieldOfView()));
             double maxNearDistance = distanceToSurface / (2 * Math.sqrt(2 * tanHalfFov * tanHalfFov + 1));
             if (near > maxNearDistance) near = maxNearDistance;
         }
@@ -1064,9 +1055,9 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         if (near < 1) near = 1;
 
         // Compute a perspective projection matrix given the WorldWindow's viewport, field of view, and clip distances.
-        projection.setToPerspectiveProjection(this.viewport.width, this.viewport.height, this.fieldOfView, near, far);
+        projection.setToPerspectiveProjection(this.viewport.width, this.viewport.height, this.camera.getFieldOfView(), near, far);
 
-        // Compute a Cartesian transform matrix from the Navigator.
-        this.navigator.getAsViewingMatrix(this.globe, modelview);
+        // Compute a Cartesian transform matrix from the Camera.
+        this.camera.computeViewingTransform(modelview);
     }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
@@ -912,7 +912,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         this.rc.fieldOfView = this.fieldOfView;
         this.rc.horizonDistance = this.globe.horizonDistance(this.navigator.getAltitude());
         this.rc.camera = this.navigator.getAsCamera(this.globe, this.rc.camera);
-        this.rc.cameraPoint = this.globe.geographicToCartesian(this.rc.camera.latitude, this.rc.camera.longitude, this.rc.camera.altitude, this.rc.cameraPoint);
+        this.rc.cameraPoint = this.globe.geographicToCartesian(this.rc.camera.position.latitude, this.rc.camera.position.longitude, this.rc.camera.position.altitude, this.rc.cameraPoint);
         this.rc.renderResourceCache = this.renderResourceCache;
         this.rc.renderResourceCache.setResources(this.getContext().getResources());
         this.rc.resources = this.getContext().getResources();

--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindowController.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindowController.java
@@ -11,7 +11,5 @@ public interface WorldWindowController {
 
     WorldWindow getWorldWindow();
 
-    void setWorldWindow(WorldWindow wwd);
-
     boolean onTouchEvent(MotionEvent event);
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/Camera.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/Camera.java
@@ -10,11 +10,7 @@ import gov.nasa.worldwind.util.Logger;
 
 public class Camera {
 
-    public double latitude;
-
-    public double longitude;
-
-    public double altitude;
+    public final Position position = new Position();
 
     @WorldWind.AltitudeMode
     public int altitudeMode = WorldWind.ABSOLUTE;
@@ -30,9 +26,7 @@ public class Camera {
 
     public Camera(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode,
                   double heading, double tilt, double roll) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
+        this.position.set(latitude, longitude, altitude);
         this.altitudeMode = altitudeMode;
         this.heading = heading;
         this.tilt = tilt;
@@ -45,9 +39,7 @@ public class Camera {
                 Logger.logMessage(Logger.ERROR, "Camera", "constructor", "missingCamera"));
         }
 
-        this.latitude = camera.latitude;
-        this.longitude = camera.longitude;
-        this.altitude = camera.altitude;
+        this.position.set(camera.position);
         this.altitudeMode = camera.altitudeMode;
         this.heading = camera.heading;
         this.tilt = camera.tilt;
@@ -56,9 +48,7 @@ public class Camera {
 
     public Camera set(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode,
                       double heading, double tilt, double roll) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
+        this.position.set(latitude, longitude, altitude);
         this.altitudeMode = altitudeMode;
         this.heading = heading;
         this.tilt = tilt;
@@ -73,9 +63,7 @@ public class Camera {
                 Logger.logMessage(Logger.ERROR, "Camera", "set", "missingCamera"));
         }
 
-        this.latitude = camera.latitude;
-        this.longitude = camera.longitude;
-        this.altitude = camera.altitude;
+        this.position.set(camera.position);
         this.altitudeMode = camera.altitudeMode;
         this.heading = camera.heading;
         this.tilt = camera.tilt;
@@ -87,9 +75,9 @@ public class Camera {
     @Override
     public String toString() {
         return "Camera{" +
-            "latitude=" + latitude +
-            ", longitude=" + longitude +
-            ", altitude=" + altitude +
+            "latitude=" + position.latitude +
+            ", longitude=" + position.longitude +
+            ", altitude=" + position.altitude +
             ", altitudeMode=" + altitudeMode +
             ", heading=" + heading +
             ", tilt=" + tilt +

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/Camera.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/Camera.java
@@ -5,10 +5,17 @@
 
 package gov.nasa.worldwind.geom;
 
+import gov.nasa.worldwind.PickedObject;
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.WorldWindow;
+import gov.nasa.worldwind.globe.Globe;
 import gov.nasa.worldwind.util.Logger;
 
 public class Camera {
+
+    private final static double COLLISION_THRESHOLD = 10.0; // 10m above surface
+
+    private final WorldWindow wwd;
 
     public final Position position = new Position();
 
@@ -21,29 +28,25 @@ public class Camera {
 
     public double roll;
 
-    public Camera() {
-    }
+    private double fieldOfView = 45;
 
-    public Camera(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode,
-                  double heading, double tilt, double roll) {
-        this.position.set(latitude, longitude, altitude);
-        this.altitudeMode = altitudeMode;
-        this.heading = heading;
-        this.tilt = tilt;
-        this.roll = roll;
-    }
+    private final Matrix4 modelview = new Matrix4();
 
-    public Camera(Camera camera) {
-        if (camera == null) {
+    private final Matrix4 origin = new Matrix4();
+
+    private final Vec3 originPoint = new Vec3();
+
+    private final Position originPos = new Position();
+
+    private final Line forwardRay = new Line();
+
+    public Camera(WorldWindow wwd) {
+        if (wwd == null) {
             throw new IllegalArgumentException(
-                Logger.logMessage(Logger.ERROR, "Camera", "constructor", "missingCamera"));
+                    Logger.logMessage(Logger.ERROR, "Camera", "constructor", "missingWorldWindow"));
         }
 
-        this.position.set(camera.position);
-        this.altitudeMode = camera.altitudeMode;
-        this.heading = camera.heading;
-        this.tilt = camera.tilt;
-        this.roll = camera.roll;
+        this.wwd = wwd;
     }
 
     public Camera set(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode,
@@ -57,6 +60,19 @@ public class Camera {
         return this;
     }
 
+    public void setFieldOfView(double fovyDegrees) {
+        if (fovyDegrees <= 0 || fovyDegrees >= 180) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "WorldWindow", "setFieldOfView", "invalidFieldOfView"));
+        }
+
+        this.fieldOfView = fovyDegrees;
+    }
+
+    public double getFieldOfView() {
+        return this.fieldOfView;
+    }
+
     public Camera set(Camera camera) {
         if (camera == null) {
             throw new IllegalArgumentException(
@@ -68,6 +84,7 @@ public class Camera {
         this.heading = camera.heading;
         this.tilt = camera.tilt;
         this.roll = camera.roll;
+        this.fieldOfView = camera.fieldOfView;
 
         return this;
     }
@@ -84,4 +101,114 @@ public class Camera {
             ", roll=" + roll +
             '}';
     }
+
+    public Matrix4 computeViewingTransform(Matrix4 result) {
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Camera", "computeViewingTransform", "missingResult"));
+        }
+
+        // TODO interpret altitude mode other than absolute
+        // Transform by the local cartesian transform at the camera's position.
+        this.wwd.getGlobe().geographicToCartesianTransform(this.position.latitude, this.position.longitude, this.position.altitude, result);
+
+        // Transform by the heading, tilt and roll.
+        result.multiplyByRotation(0, 0, 1, -this.heading); // rotate clockwise about the Z axis
+        result.multiplyByRotation(1, 0, 0, this.tilt); // rotate counter-clockwise about the X axis
+        result.multiplyByRotation(0, 0, 1, this.roll); // rotate counter-clockwise about the Z axis (again)
+
+        // Make the transform a viewing matrix.
+        result.invertOrthonormal();
+
+        return result;
+    }
+
+    public LookAt getAsLookAt(LookAt result) {
+        Globe globe = this.wwd.getGlobe();
+
+        this.computeViewingTransform(this.modelview);
+
+        // Pick terrain located behind the viewport center point
+        PickedObject terrainPickedObject = wwd.pick(wwd.getViewport().width / 2f, wwd.getViewport().height / 2f).terrainPickedObject();
+        if (terrainPickedObject != null) {
+            // Use picked terrain position including approximate rendered altitude
+            this.originPos.set(terrainPickedObject.getTerrainPosition());
+            globe.geographicToCartesian(this.originPos.latitude, this.originPos.longitude, this.originPos.altitude, this.originPoint);
+            globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
+        } else {
+            // Center is outside the globe - use point on horizon
+            this.modelview.extractEyePoint(this.forwardRay.origin);
+            this.modelview.extractForwardVector(this.forwardRay.direction);
+            this.forwardRay.pointAt(globe.horizonDistance(this.position.altitude), this.originPoint);
+            globe.cartesianToGeographic(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.originPos);
+            globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
+        }
+
+        this.modelview.multiplyByMatrix(this.origin);
+
+        result.position.set(this.originPos);
+        result.range = -this.modelview.m[11];
+        result.heading = this.modelview.extractHeading(this.roll); // disambiguate heading and roll
+        result.tilt = this.modelview.extractTilt();
+        result.roll = this.roll; // roll passes straight through
+
+        return result;
+    }
+
+    public Camera setFromLookAt(LookAt lookAt) {
+        Globe globe = this.wwd.getGlobe();
+
+        this.lookAtToViewingTransform(lookAt, this.modelview);
+        this.modelview.extractEyePoint(this.originPoint);
+
+        globe.cartesianToGeographic(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.originPos);
+        globe.cartesianToLocalTransform(this.originPoint.x, this.originPoint.y, this.originPoint.z, this.origin);
+        this.modelview.multiplyByMatrix(this.origin);
+
+        this.position.set(this.originPos);
+        this.heading = this.modelview.extractHeading(lookAt.roll); // disambiguate heading and roll
+        this.tilt = this.modelview.extractTilt();
+        this.roll = lookAt.roll; // roll passes straight through
+
+        // Check if camera altitude is not under the surface
+        double elevation = globe.getElevationAtLocation(this.position.latitude, this.position.longitude) * wwd.getVerticalExaggeration() + COLLISION_THRESHOLD;
+        if(elevation > this.position.altitude) {
+            // Set camera altitude above the surface
+            this.position.altitude = elevation;
+            // Compute new camera point
+            globe.geographicToCartesian(this.position.latitude, this.position.longitude, this.position.altitude, originPoint);
+            // Compute look at point
+            globe.geographicToCartesian(lookAt.position.latitude, lookAt.position.longitude, lookAt.position.altitude, forwardRay.origin);
+            // Compute normal to globe in look at point
+            globe.geographicToCartesianNormal(lookAt.position.latitude, lookAt.position.longitude, forwardRay.direction);
+            // Calculate tilt angle between new camera point and look at point
+            originPoint.subtract(forwardRay.origin).normalize();
+            double dot = forwardRay.direction.dot(originPoint);
+            if (dot >= -1 || dot <= 1) {
+                this.tilt = Math.toDegrees(Math.acos(dot));
+            }
+        }
+
+        return this;
+    }
+
+    protected Matrix4 lookAtToViewingTransform(LookAt lookAt, Matrix4 result) {
+        // TODO interpret altitude mode other than absolute
+        // Transform by the local cartesian transform at the look-at's position.
+        this.wwd.getGlobe().geographicToCartesianTransform(lookAt.position.latitude, lookAt.position.longitude, lookAt.position.altitude, result);
+
+        // Transform by the heading and tilt.
+        result.multiplyByRotation(0, 0, 1, -lookAt.heading); // rotate clockwise about the Z axis
+        result.multiplyByRotation(1, 0, 0, lookAt.tilt); // rotate counter-clockwise about the X axis
+        result.multiplyByRotation(0, 0, 1, lookAt.roll); // rotate counter-clockwise about the Z axis (again)
+
+        // Transform by the range.
+        result.multiplyByTranslation(0, 0, lookAt.range);
+
+        // Make the transform a viewing matrix.
+        result.invertOrthonormal();
+
+        return result;
+    }
+
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/Location.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/Location.java
@@ -127,7 +127,7 @@ public class Location {
     }
 
     /**
-     * Constructs an approximate location for a specified time zone. Used when selecting an initial navigator position
+     * Constructs an approximate location for a specified time zone. Used when selecting an initial camera position
      * based on the device's current time zone.
      *
      * @param timeZone the time zone in question

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/LookAt.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/LookAt.java
@@ -10,11 +10,7 @@ import gov.nasa.worldwind.util.Logger;
 
 public class LookAt {
 
-    public double latitude;
-
-    public double longitude;
-
-    public double altitude;
+    public final Position position = new Position();
 
     @WorldWind.AltitudeMode
     public int altitudeMode = WorldWind.ABSOLUTE;
@@ -32,9 +28,7 @@ public class LookAt {
 
     public LookAt(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode, double range,
                   double heading, double tilt, double roll) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
+        this.position.set(latitude, longitude, altitude);
         this.altitudeMode = altitudeMode;
         this.range = range;
         this.heading = heading;
@@ -48,9 +42,7 @@ public class LookAt {
                 Logger.logMessage(Logger.ERROR, "LookAt", "constructor", "missingLookAt"));
         }
 
-        this.latitude = lookAt.latitude;
-        this.longitude = lookAt.longitude;
-        this.altitude = lookAt.altitude;
+        this.position.set(lookAt.position);
         this.altitudeMode = lookAt.altitudeMode;
         this.range = lookAt.range;
         this.heading = lookAt.heading;
@@ -60,9 +52,7 @@ public class LookAt {
 
     public LookAt set(double latitude, double longitude, double altitude, @WorldWind.AltitudeMode int altitudeMode, double range,
                       double heading, double tilt, double roll) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
+        this.position.set(latitude, longitude, altitude);
         this.altitudeMode = altitudeMode;
         this.range = range;
         this.heading = heading;
@@ -78,9 +68,7 @@ public class LookAt {
                 Logger.logMessage(Logger.ERROR, "LookAt", "set", "missingLookAt"));
         }
 
-        this.latitude = lookAt.latitude;
-        this.longitude = lookAt.longitude;
-        this.altitude = lookAt.altitude;
+        this.position.set(lookAt.position);
         this.altitudeMode = lookAt.altitudeMode;
         this.range = lookAt.range;
         this.heading = lookAt.heading;
@@ -93,9 +81,9 @@ public class LookAt {
     @Override
     public String toString() {
         return "LookAt{" +
-            "latitude=" + latitude +
-            ", longitude=" + longitude +
-            ", altitude=" + altitude +
+            "latitude=" + position.latitude +
+            ", longitude=" + position.longitude +
+            ", altitude=" + position.altitude +
             ", altitudeMode=" + altitudeMode +
             ", range=" + range +
             ", heading=" + heading +

--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/PanRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/PanRecognizer.java
@@ -43,6 +43,14 @@ public class PanRecognizer extends GestureRecognizer {
         this.maxNumberOfPointers = count;
     }
 
+    public float getInterpretDistance() {
+        return this.interpretDistance;
+    }
+
+    public void setInterpretDistance(float distance) {
+        this.interpretDistance = distance;
+    }
+
     @Override
     protected void actionMove(MotionEvent event) {
         int state = this.getState();

--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/PinchRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/PinchRecognizer.java
@@ -37,6 +37,14 @@ public class PinchRecognizer extends GestureRecognizer {
         return this.scale * this.scaleOffset;
     }
 
+    public float getInterpretDistance() {
+        return this.interpretDistance;
+    }
+
+    public void setInterpretDistance(float distance) {
+        this.interpretDistance = distance;
+    }
+
     @Override
     protected void reset() {
         super.reset();

--- a/worldwind/src/main/java/gov/nasa/worldwind/gesture/RotationRecognizer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/gesture/RotationRecognizer.java
@@ -35,6 +35,14 @@ public class RotationRecognizer extends GestureRecognizer {
         return (float) WWMath.normalizeAngle180(this.rotation + this.rotationOffset);
     }
 
+    public float getInterpretAngle() {
+        return this.interpretAngle;
+    }
+
+    public void setInterpretAngle(float angle) {
+        this.interpretAngle = angle;
+    }
+
     protected void reset() {
         super.reset();
         this.rotation = 0;

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/AbstractLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/AbstractLayer.java
@@ -136,7 +136,7 @@ public abstract class AbstractLayer implements Layer {
 
     @Override
     public boolean isWithinActiveAltitudes(RenderContext rc) {
-        double cameraAltitude = rc.camera.altitude;
+        double cameraAltitude = rc.camera.position.altitude;
         return cameraAltitude >= this.minActiveAltitude && cameraAltitude <= this.maxActiveAltitude;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/AbstractGraticuleLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/AbstractGraticuleLayer.java
@@ -391,7 +391,7 @@ public abstract class AbstractGraticuleLayer extends AbstractLayer {
                     Location.normalizeLongitude(labelPos.longitude));
             return labelPos;
         } else {
-            return Location.fromDegrees(rc.camera.latitude, rc.camera.longitude);
+            return rc.camera.position;
         }
     }
 
@@ -444,7 +444,7 @@ public abstract class AbstractGraticuleLayer extends AbstractLayer {
     }
 
     double computeAltitudeAboveGround(RenderContext rc) {
-        Vec3 surfacePoint = getSurfacePoint(rc, rc.camera.latitude, rc.camera.longitude);
+        Vec3 surfacePoint = getSurfacePoint(rc, rc.camera.position.latitude, rc.camera.position.longitude);
         return rc.cameraPoint.distanceTo(surfacePoint);
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/AbstractGraticuleLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/AbstractGraticuleLayer.java
@@ -325,7 +325,7 @@ public abstract class AbstractGraticuleLayer extends AbstractLayer {
         if (Math.abs(this.lastCameraTilt - rc.camera.tilt) > 1)
             return true;
 
-        if (Math.abs(this.lastFOV - rc.fieldOfView) > 1)
+        if (Math.abs(this.lastFOV - rc.camera.getFieldOfView()) > 1)
             return true;
 
         if (rc.cameraPoint.distanceTo(this.lastCameraPoint) > computeAltitudeAboveGround(rc) / 100)  // 1% of AAG
@@ -348,7 +348,7 @@ public abstract class AbstractGraticuleLayer extends AbstractLayer {
     protected void clear(RenderContext rc) {
         this.removeAllRenderables();
         this.lastCameraPoint.set(rc.cameraPoint);
-        this.lastFOV = rc.fieldOfView;
+        this.lastFOV = rc.camera.getFieldOfView();
         this.lastCameraHeading = rc.camera.heading;
         this.lastCameraTilt = rc.camera.tilt;
         this.lastVerticalExaggeration = rc.verticalExaggeration;

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/GARSGraticuleTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/GARSGraticuleTile.java
@@ -123,7 +123,7 @@ class GARSGraticuleTile extends AbstractGraticuleTile {
 
     @Override
     boolean isInView(RenderContext rc) {
-        return super.isInView(rc) && (this.level == 0 || rc.camera.altitude <= THRESHOLDS[this.level - 1]);
+        return super.isInView(rc) && (this.level == 0 || rc.camera.position.altitude <= THRESHOLDS[this.level - 1]);
     }
 
     @Override
@@ -131,7 +131,7 @@ class GARSGraticuleTile extends AbstractGraticuleTile {
         super.selectRenderables(rc);
 
         String graticuleType = getLayer().getTypeFor(this.getSector().deltaLatitude());
-        if (this.level == 0 && rc.camera.altitude > THRESHOLDS[0]) {
+        if (this.level == 0 && rc.camera.position.altitude > THRESHOLDS[0]) {
             Location labelOffset = getLayer().computeLabelOffset(rc);
 
             for (GridElement ge : this.getGridElements()) {
@@ -149,12 +149,12 @@ class GARSGraticuleTile extends AbstractGraticuleTile {
                 }
             }
 
-            if (rc.camera.altitude > THRESHOLDS[0])
+            if (rc.camera.position.altitude > THRESHOLDS[0])
                 return;
         }
 
         // Select tile grid elements
-        double eyeDistance = rc.camera.altitude;
+        double eyeDistance = rc.camera.position.altitude;
 
         if (this.level == 0 && eyeDistance <= THRESHOLDS[0]
             || this.level == 1 && eyeDistance <= THRESHOLDS[1]

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/MGRSGraticuleLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/MGRSGraticuleLayer.java
@@ -120,7 +120,7 @@ public class MGRSGraticuleLayer extends AbstractUTMGraticuleLayer {
 
     @Override
     protected void selectRenderables(RenderContext rc) {
-        if (rc.camera.altitude <= GRID_ZONE_MAX_ALTITUDE) {
+        if (rc.camera.position.altitude <= GRID_ZONE_MAX_ALTITUDE) {
             this.selectMGRSRenderables(rc);
             super.selectRenderables(rc);
         } else {

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/MGRSGridZone.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/graticule/MGRSGridZone.java
@@ -63,7 +63,7 @@ class MGRSGridZone extends AbstractGraticuleTile {
                 getLayer().addRenderable(ge.renderable, graticuleType);
             }
 
-        if (rc.camera.altitude > SQUARE_MAX_ALTITUDE)
+        if (rc.camera.position.altitude > SQUARE_MAX_ALTITUDE)
             return;
 
         // Select 100km squares elements

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -52,11 +52,9 @@ public class RenderContext {
 
     public double verticalExaggeration = 1;
 
-    public double fieldOfView;
-
     public double horizonDistance;
 
-    public Camera camera = new Camera();
+    public Camera camera;
 
     public Vec3 cameraPoint = new Vec3();
 
@@ -116,9 +114,8 @@ public class RenderContext {
         this.layers = null;
         this.currentLayer = null;
         this.verticalExaggeration = 1;
-        this.fieldOfView = 0;
         this.horizonDistance = 0;
-        this.camera.set(0, 0, 0, WorldWind.ABSOLUTE /*lat, lon, alt*/, 0, 0, 0 /*heading, tilt, roll*/);
+        this.camera = null;
         this.cameraPoint.set(0, 0, 0);
         this.viewport.setEmpty();
         this.projection.setToIdentity();
@@ -161,7 +158,7 @@ public class RenderContext {
      */
     public double pixelSizeAtDistance(double distance) {
         if (this.pixelSizeFactor == 0) { // cache the scaling factor used to convert distances to pixel sizes
-            double fovyDegrees = this.fieldOfView;
+            double fovyDegrees = this.camera.getFieldOfView();
             double tanfovy_2 = Math.tan(Math.toRadians(fovyDegrees * 0.5));
             this.pixelSizeFactor = 2 * tanfovy_2 / this.viewport.height;
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/AbstractShape.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/AbstractShape.java
@@ -155,8 +155,8 @@ public abstract class AbstractShape extends AbstractRenderable implements Attrib
     }
 
     protected double cameraDistanceGeographic(RenderContext rc, Sector boundingSector) {
-        double lat = WWMath.clamp(rc.camera.latitude, boundingSector.minLatitude(), boundingSector.maxLatitude());
-        double lon = WWMath.clamp(rc.camera.longitude, boundingSector.minLongitude(), boundingSector.maxLongitude());
+        double lat = WWMath.clamp(rc.camera.position.latitude, boundingSector.minLatitude(), boundingSector.maxLatitude());
+        double lon = WWMath.clamp(rc.camera.position.longitude, boundingSector.minLongitude(), boundingSector.maxLongitude());
         Vec3 point = rc.geographicToCartesian(lat, lon, 0, WorldWind.CLAMP_TO_GROUND, this.scratchPoint);
 
         return point.distanceTo(rc.cameraPoint);

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -433,16 +433,16 @@ public class Tile {
      */
     protected double distanceToCamera(RenderContext rc) {
         // determine the nearest latitude
-        double nearestLat = WWMath.clamp(rc.camera.latitude, this.sector.minLatitude(), this.sector.maxLatitude());
+        double nearestLat = WWMath.clamp(rc.camera.position.latitude, this.sector.minLatitude(), this.sector.maxLatitude());
         // determine the nearest longitude and account for the antimeridian discontinuity
         double nearestLon;
-        double lonDifference = rc.camera.longitude - this.sector.centroidLongitude();
+        double lonDifference = rc.camera.position.longitude - this.sector.centroidLongitude();
         if (lonDifference < -180.0) {
             nearestLon = this.sector.maxLongitude();
         } else if (lonDifference > 180.0) {
             nearestLon = this.sector.minLongitude();
         } else {
-            nearestLon = WWMath.clamp(rc.camera.longitude, this.sector.minLongitude(), this.sector.maxLongitude());
+            nearestLon = WWMath.clamp(rc.camera.position.longitude, this.sector.minLongitude(), this.sector.maxLongitude());
         }
 
         float minHeight = (float) (this.heightLimits[0] * rc.verticalExaggeration);

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/WWMath.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/WWMath.java
@@ -186,7 +186,7 @@ public class WWMath {
      */
     public static double normalizeAngle360(double degrees) {
         double angle = degrees % 360;
-        return angle >= 0 ? angle : (angle < 0 ? 360 + angle : 360 - angle);
+        return angle >= 0 ? angle : 360 + angle;
     }
 
     /**

--- a/worldwind/src/main/res/values/dimens.xml
+++ b/worldwind/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Gesture detector -->
+    <dimen name="pan_interpret_distance">20dp</dimen>
+    <dimen name="pinch_interpret_distance">20dp</dimen>
+    <dimen name="tilt_interpret_distance">20dp</dimen>
+</resources>

--- a/worldwind/src/test/java/gov/nasa/worldwind/WorldWindowTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/WorldWindowTest.java
@@ -44,34 +44,6 @@ public class WorldWindowTest {
 
     @Ignore
     @Test
-    public void testGetNavigator() throws Exception {
-        fail("The test case is a stub");
-
-    }
-
-    @Ignore
-    @Test
-    public void testSetNavigator() throws Exception {
-        fail("The test case is a stub");
-
-    }
-
-    @Ignore
-    @Test
-    public void testGetNavigatorController() throws Exception {
-        fail("The test case is a stub");
-
-    }
-
-    @Ignore
-    @Test
-    public void testSetNavigatorController() throws Exception {
-        fail("The test case is a stub");
-
-    }
-
-    @Ignore
-    @Test
     public void testGetFrameController() throws Exception {
         fail("The test case is a stub");
 

--- a/worldwind/src/test/java/gov/nasa/worldwind/geom/FrustumTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/geom/FrustumTest.java
@@ -15,7 +15,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import gov.nasa.worldwind.Navigator;
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.globe.Globe;
 import gov.nasa.worldwind.globe.ProjectionWgs84;
@@ -177,7 +176,7 @@ public class FrustumTest {
         assertFalse("outside far", frustum.intersectsSegment(new Vec3(0, 0, 2), new Vec3(0, 0, 1.0000001)));
     }
 
-// NOTE Navigator is now dependent on WorldWindow instance which is dependent on Android Context. Move this tests to androidTest section?
+// NOTE Camera is now dependent on WorldWindow instance which is dependent on Android Context. Move this tests to androidTest section?
 //    @Test
 //    public void testSetToModelviewProjection() throws Exception {
 //        // The expected test values were obtained via SystemOut on Frustum object
@@ -187,21 +186,21 @@ public class FrustumTest {
 //
 //        // Create a Frustum similar to the way the WorldWindow does it.
 //
-//        // Setup a Navigator, looking near Oxnard Airport.
+//        // Setup a Camera, looking near Oxnard Airport.
 //        LookAt lookAt = new LookAt().set(34.15, -119.15, 0, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-//        Navigator navigator = new Navigator();
-//        navigator.setAsLookAt(globe, lookAt);
+//        Camera camera = new Camera(wwd);
+//        camera.setFromLookAt(lookAt);
 //
 //        // Compute a perspective projection matrix given the viewport, field of view, and clip distances.
 //        Viewport viewport = new Viewport(0, 0, 100, 100);  // screen coordinates
-//        double nearDistance = navigator.getAltitude() * 0.75;
-//        double farDistance = globe.horizonDistance(navigator.getAltitude()) + globe.horizonDistance(160000);
+//        double nearDistance = camera.position.altitude * 0.75;
+//        double farDistance = globe.horizonDistance(camera.position.altitude) + globe.horizonDistance(160000);
 //        Matrix4 projection = new Matrix4();
 //        projection.setToPerspectiveProjection(viewport.width, viewport.height, 45d /*fovy*/, nearDistance, farDistance);
 //
-//        // Compute a Cartesian viewing matrix using this Navigator's properties as a Camera.
+//        // Compute a Cartesian viewing matrix using this Camera's properties as a Camera.
 //        Matrix4 modelview = new Matrix4();
-//        navigator.getAsViewingMatrix(globe, modelview);
+//        camera.computeViewingTransform(modelview);
 //
 //        // Compute the Frustum
 //        Frustum frustum = new Frustum();
@@ -234,22 +233,22 @@ public class FrustumTest {
 //
 //        // Create a Frustum similar to the way the WorldWindow does it when picking
 //
-//        // Setup a Navigator, looking near Oxnard Airport.
+//        // Setup a Camera, looking near Oxnard Airport.
 //        LookAt lookAt = new LookAt().set(34.15, -119.15, 0, WorldWind.ABSOLUTE, 2e4 /*range*/, 0 /*heading*/, 45 /*tilt*/, 0 /*roll*/);
-//        Navigator navigator = new Navigator();
-//        navigator.setAsLookAt(globe, lookAt);
+//        Camera camera = new Camera(wwd);
+//        camera.setFromLookAt(lookAt);
 //
 //        // Compute a perspective projection matrix given the viewport, field of view, and clip distances.
 //        Viewport viewport = new Viewport(0, 0, 100, 100);  // screen coordinates
 //        Viewport pickViewport = new Viewport(49, 49, 3, 3); // 3x3 viewport centered on a pick point
-//        double nearDistance = navigator.getAltitude() * 0.75;
-//        double farDistance = globe.horizonDistance(navigator.getAltitude()) + globe.horizonDistance(160000);
+//        double nearDistance = camera.position.altitude * 0.75;
+//        double farDistance = globe.horizonDistance(camera.position.altitude) + globe.horizonDistance(160000);
 //        Matrix4 projection = new Matrix4();
 //        projection.setToPerspectiveProjection(viewport.width, viewport.height, 45d /*fovy*/, nearDistance, farDistance);
 //
-//        // Compute a Cartesian viewing matrix using this Navigator's properties as a Camera.
+//        // Compute a Cartesian viewing matrix using this Camera's properties as a Camera.
 //        Matrix4 modelview = new Matrix4();
-//        navigator.getAsViewingMatrix(globe, modelview);
+//        camera.computeViewingTransform(modelview);
 //
 //        // Compute the Frustum
 //        Frustum frustum = new Frustum();


### PR DESCRIPTION
### Description of the Change
Deprecate Navigator class and control Camera directly like in JS codebase.
Move LookAt point conversion routine into Camera class.
Move field of view into Camera class.
Use Position object instead of separate latitude, longitude and altitude attributes in Camera and LookAt.
Use two-fingers tilt. Do not change heading on tilt.
Use gesture interpret distance in DP respecting screen density instead of PX.
Update documentation templates according to new API.
Add additional zoomIn, zoomOut and resetOrientation commands to BasicWorldWindowController.


### Why Should This Be In Core?
Slightly improves UX.

### Benefits
Slightly improves UX.
Simplify Camera control.

### Potential Drawbacks
May be partially incompatible with old customer applications.

### Applicable Issues
#6 
#8 
#21 