### PR TITLE
Bugfix for Placemark.setPosition with new Label

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -286,6 +286,10 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
         } else {
             this.position.set(position);
         }
+        // We must also move this.label to follow the icon
+        if (this.label != null) {
+            this.label.setPosition(position);
+        }
         return this;
     }
 


### PR DESCRIPTION

### Description of the Change
This is a bugfix for icons with labels that move; with only the change in #25 (5d360fa4bcf24730b809d164161cb62c3c3ce997) the label remains at the old position.

### Why Should This Be In Core?

It fixes a bug.

### Benefits

It fixes a bug.

### Potential Drawbacks

None; we check for an NPE before doing anything with the `label` so this should not affect unlabeled icons.

### Applicable Issues

PR #25 
