### PR TITLE
Bugfix for Placemark.setLabel with pre-existing Label

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -407,6 +407,9 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
         if (this.label == null) {
             this.label = new Label(this.getPosition(), label);
         }
+        else {
+            this.label.setText(label);
+        }
         return this;
     }
 


### PR DESCRIPTION

### Description of the Change

This fixes a bug where calling `Placemark.setLabel("a")` then `Placemark.setLabel("b")` would leave the placemark's label unmodified.

### Why Should This Be In Core?
It fixes a bug.

### Benefits
It fixes a bug.

### Potential Drawbacks
None.

### Applicable Issues

PRs #25 and #26 