### PR TITLE
Dvt improvements 2020

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/render/ImageRetriever.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/ImageRetriever.java
@@ -11,9 +11,15 @@ import android.graphics.BitmapFactory;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileInputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.util.Logger;
@@ -95,9 +101,13 @@ public class ImageRetriever extends Retriever<ImageSource, ImageOptions, Bitmap>
     }
 
     protected Bitmap decodeUrl(String urlString, ImageOptions imageOptions) throws IOException {
-        // TODO establish a file caching service for remote resources
         // TODO retry absent resources, they are currently handled but suppressed entirely after the first failure
         // TODO configurable connect and read timeouts
+
+        Bitmap cached = attemptGlobalCacheSourceResolution(urlString);
+        if (cached != null) {
+            return cached;
+        }
 
         InputStream stream = null;
         try {
@@ -108,10 +118,117 @@ public class ImageRetriever extends Retriever<ImageSource, ImageOptions, Bitmap>
             stream = new BufferedInputStream(conn.getInputStream());
 
             BitmapFactory.Options factoryOptions = this.bitmapFactoryOptions(imageOptions);
-            return BitmapFactory.decodeStream(stream, null, factoryOptions);
+            Bitmap fetchedBmp = BitmapFactory.decodeStream(stream, null, factoryOptions);
+            if (fetchedBmp != null) {
+                addToGlobalCache(urlString, fetchedBmp);
+            }
+            return fetchedBmp;
         } finally {
             WWUtil.closeSilently(stream);
         }
+    }
+
+    protected Bitmap attemptGlobalCacheSourceResolution(String urlString) {
+        // At the moment the cache directory is global for all ImageRetrievers in a given JVM.
+        // Minor // TODO may be to add a configuration object to this class for setting per-retriever cache directories.
+        String cacheDir = System.getProperty("worldwind.ImageRetriever.decodeUrlCacheDir");
+        if (cacheDir == null) {
+            return null; // Calling app did not set a cache dir
+        }
+        File cacheDirFD = new File(cacheDir);
+        if (!cacheDirFD.exists()) {
+            try {
+                cacheDirFD.mkdirs();
+            }
+            catch (SecurityException sx) {
+                Logger.logMessage(Logger.ERROR, "ImageRetriever", "attemptGlobalCacheSourceResolution", "Cannot create cache directory");
+                return null; // Coult not create cache dir
+            }
+        }
+
+        File cacheFileFD = getGlobalCacheUrlFile(urlString);
+        if (!cacheFileFD.exists()) {
+            return null;
+        }
+        long fileSizeInBytes = cacheFileFD.length();
+        if (fileSizeInBytes < 1) {
+            return null; // File exists, but is empty.
+        }
+        Bitmap bmp = null;
+        try {
+            bmp = BitmapFactory.decodeStream(new FileInputStream(cacheFileFD));
+        }
+        catch (FileNotFoundException fnfex) {
+            Logger.logMessage(Logger.ERROR, "ImageRetriever", "attemptGlobalCacheSourceResolution", "Cannot decode cache file into Bitmap");
+        }
+        return bmp;
+    }
+
+    protected void addToGlobalCache(String urlString, Bitmap bitmap) {
+        File cacheFileFD = getGlobalCacheUrlFile(urlString);
+        try (FileOutputStream out = new FileOutputStream(cacheFileFD)) {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+        }
+        catch (IOException e) {
+            Logger.logMessage(Logger.ERROR, "ImageRetriever", "addToGlobalCache", "Cannot write bitmap to cache file");
+        }
+    }
+
+    /**
+     * This performs concatination of {@code System.getProperty("worldwind.ImageRetriever.decodeUrlCacheDir")}
+     * with a SHA-256 hex string of {@code urlString}, returning {@code null} if
+     * anything does not exist ({@code System.getProperty("worldwind.ImageRetriever.decodeUrlCacheDir") == null} etc)
+     * 
+     * This will NOT create a cache directory, and instead returns null when the directory path stored in
+     * {@code System.getProperty("worldwind.ImageRetriever.decodeUrlCacheDir")} does not exist.
+     *
+     * This has been made public and static to as to be used elsewhere; this likely deserves a class
+     * of it's own as it performs a caching operation which is not unique to ImageRetriever.
+     * 
+     * @param urlString The url which produces the cached file's name
+     * @param fileNameFormatStr A format string which takes a single %s argument used to create the cache file name.
+     * @return a file object pointing to the cached file (file may not exist)
+     */
+    public static File getGlobalCacheUrlFile(String urlString, String fileNameFormatStr) {
+        String cacheDir = System.getProperty("worldwind.ImageRetriever.decodeUrlCacheDir");
+        if (cacheDir == null) {
+            return null;
+        }
+        File cacheDirFD = new File(cacheDir);
+        if (!cacheDirFD.exists()) {
+            return null;
+        }
+
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        }
+        catch (NoSuchAlgorithmException nsax) {
+            Logger.logMessage(Logger.ERROR, "ImageRetriever", "getGlobalCacheUrlFile", "No MessageDigest instance available for \"SHA-256\"");
+            return null; // No sha-256 hash implementation for us to use
+        }
+
+        md.update(urlString.getBytes());
+
+        byte[] digest = md.digest();
+        String digestStr = decodeTohexStr(digest).toUpperCase();
+
+        // At the moment all cached bitmaps are stored as .png files
+        String cacheFilename = String.format(fileNameFormatStr, digestStr);
+        File cacheFileFD = new File(cacheDirFD, cacheFilename);
+
+        return cacheFileFD;
+    }
+    public static File getGlobalCacheUrlFile(String urlString) {
+        return getGlobalCacheUrlFile(urlString, "%s.png");
+    }
+
+    private static String decodeTohexStr(byte[] data) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : data) {
+            sb.append(String.format("%02X ", b));
+        }
+        return sb.toString();
     }
 
     protected Bitmap decodeUnrecognized(ImageSource imageSource) {


### PR DESCRIPTION
### Description of the Change

This adds a global cache for all WMS layers if the calling code sets the system property "worldwind.ImageRetriever.decodeUrlCacheDir". The cache stores WMS Capabilities as a .xml file as well as a .PNG tile for every URL processed through `gov.nasa.worldwind.render.ImageRetriever`.

### Why Should This Be In Core?

I'm not 100% certain this should be in core, but there have been previous discussions on the worldwind forum which indicate this capability is desired:

https://forum.worldwindcentral.com/forum/worldwind-android-wwa/android-discussion/17902-android-offline-mode

This PR should open a discussion about what the most idiomatic way to add file caches to `LayerFactory` and `ImageRetriever` such that

1. Existing code does not need to be modified
2. Callers get some way to clear the cache (at the moment these changes do not handle invalidating the cache)

### Benefits

Offline imagery is useful for a number of organizations (This change originated internally at https://devil-tech.com/, we are certainly interested in using offline data for an application we write).

### Potential Drawbacks

This is a global cache which uses a system property to modify behavior. This is likely not idiomatic code for the WW community and I'd like to hear feedback on a more appropriate approach.

### Applicable Issues

https://github.com/NASAWorldWind/WorldWindAndroid/issues/3

https://github.com/NASAWorldWind/WorldWindAndroid/issues/72
