### PR TITLE
Fix GeoPackage processing

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import gov.nasa.worldwind.draw.BasicDrawableTerrain;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Range;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
@@ -32,7 +33,7 @@ import gov.nasa.worldwind.util.TileFactory;
 public class BasicTessellator implements Tessellator, TileFactory {
 
     // ~0.6 meter resolution
-    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), 90, 20, 32, 32);
+    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 90, 20, 32, 32);
 
     protected double detailControl = 80;
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.ogc.WmsLayerConfig;
 import gov.nasa.worldwind.ogc.WmsTileFactory;
@@ -670,7 +671,7 @@ public class LayerFactory {
         }
         int imageSize = tileMatrixSet.getTileMatrices().get(0).getTileHeight();
 
-        return new LevelSet(boundingBox, 90.0, compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
+        return new LevelSet(boundingBox, new Location(-90, -180), 90, compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
     }
 
     protected String buildWmtsKvpTemplate(String kvpServiceAddress, String layer, String format, String styleIdentifier, String tileMatrixSet) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -8,6 +8,7 @@ package gov.nasa.worldwind.layer;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.SparseArray;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
@@ -30,6 +31,7 @@ import gov.nasa.worldwind.ogc.gpkg.GeoPackage;
 import gov.nasa.worldwind.ogc.gpkg.GpkgContent;
 import gov.nasa.worldwind.ogc.gpkg.GpkgSpatialReferenceSystem;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileFactory;
+import gov.nasa.worldwind.ogc.gpkg.GpkgTileMatrix;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileMatrixSet;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileUserMetrics;
 import gov.nasa.worldwind.ogc.wms.WmsCapabilities;
@@ -259,6 +261,13 @@ public class LayerFactory {
                 continue;
             }
 
+            SparseArray<GpkgTileMatrix> tileMatrix = geoPackage.getTileMatrix(content.getTableName());
+            if (tileMatrix == null || tileMatrix.size() == 0) {
+                Logger.logMessage(Logger.WARN, "LayerFactory", "createFromGeoPackageAsync",
+                        "Unsupported GeoPackage tile matrix");
+                continue;
+            }
+
             GpkgTileUserMetrics tileMetrics = geoPackage.getTileUserMetrics(content.getTableName());
             if (tileMetrics == null) {
                 Logger.logMessage(Logger.WARN, "LayerFactory", "createFromGeoPackageAsync",
@@ -267,14 +276,15 @@ public class LayerFactory {
             }
 
             LevelSetConfig config = new LevelSetConfig();
-            config.sector.set(content.getMinY(), content.getMinX(),
-                content.getMaxY() - content.getMinY(), content.getMaxX() - content.getMinX());
-            config.firstLevelDelta = 180;
-            config.numLevels = tileMetrics.getMaxZoomLevel() + 1; // zero when there are no zoom levels, (0 = -1 + 1)
-            config.tileWidth = 256;
-            config.tileHeight = 256;
+            config.sector.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX(),
+                    tileMatrixSet.getMaxY() - tileMatrixSet.getMinY(),
+                    tileMatrixSet.getMaxX() - tileMatrixSet.getMinX());
+            config.tileOrigin.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX());
+            config.firstLevelDelta = (tileMatrixSet.getMaxY() - tileMatrixSet.getMinY()) / tileMatrix.valueAt(0).getMatrixHeight();
+            config.numLevels = tileMatrix.size();
 
             TiledSurfaceImage surfaceImage = new TiledSurfaceImage();
+            surfaceImage.setDisplayName(content.getIdentifier());
             surfaceImage.setLevelSet(new LevelSet(config));
             surfaceImage.setTileFactory(new GpkgTileFactory(content));
             gpkgRenderables.addRenderable(surfaceImage);

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 
 import java.util.Collection;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.render.ImageSource;
 import gov.nasa.worldwind.render.ImageTile;
 import gov.nasa.worldwind.util.Level;
@@ -51,19 +52,20 @@ class MercatorImageTile extends ImageTile implements ImageSource.Transformer {
 
         // NOTE LevelSet.sector is final Sector attribute and thus can not be cast to MercatorSector!
         MercatorSector sector = MercatorSector.fromSector(level.parent.sector);
+        Location tileOrigin = level.parent.tileOrigin;
         double dLat = level.tileDelta / 2;
         double dLon = level.tileDelta;
 
-        int firstRow = Tile.computeRow(dLat, sector.minLatitude());
-        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude());
-        int firstCol = Tile.computeColumn(dLon, sector.minLongitude());
-        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude());
+        int firstRow = Tile.computeRow(dLat, sector.minLatitude(), tileOrigin.latitude);
+        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude(), tileOrigin.latitude);
+        int firstCol = Tile.computeColumn(dLon, sector.minLongitude(), tileOrigin.longitude);
+        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude(), tileOrigin.longitude);
 
         double deltaLat = dLat / 90;
         double d1 = sector.minLatPercent() + deltaLat * firstRow;
         for (int row = firstRow; row <= lastRow; row++) {
             double d2 = d1 + deltaLat;
-            double t1 = sector.minLongitude() + (firstCol * dLon);
+            double t1 = tileOrigin.longitude + (firstCol * dLon);
             for (int col = firstCol; col <= lastCol; col++) {
                 double t2;
                 t2 = t1 + dLon;

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
@@ -1,6 +1,7 @@
 package gov.nasa.worldwind.layer.mercator;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.layer.RenderableLayer;
 import gov.nasa.worldwind.render.ImageOptions;
@@ -23,7 +24,7 @@ public abstract class MercatorTiledImageLayer extends RenderableLayer implements
 
         MercatorTiledSurfaceImage surfaceImage = new MercatorTiledSurfaceImage();
         surfaceImage.setLevelSet(new LevelSet(
-                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2),
+                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2), new Location(-90, -180),
                 FULL_SPHERE / (1 << firstLevelOffset), numLevels - firstLevelOffset, tileSize, tileSize));
         surfaceImage.setTileFactory(this);
         if(!overlay) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
@@ -67,8 +67,8 @@ public class Level {
 
         this.parent = parent;
         this.levelNumber = levelNumber;
-        this.levelWidth = (int) Math.round(parent.tileWidth * 360 / tileDelta);
-        this.levelHeight = (int) Math.round(parent.tileHeight * 180 / tileDelta);
+        this.levelWidth = (int) Math.round(parent.tileWidth * parent.sector.deltaLongitude() / tileDelta);
+        this.levelHeight = (int) Math.round(parent.tileHeight * parent.sector.deltaLatitude() / tileDelta);
         this.tileDelta = tileDelta;
         this.tileWidth = parent.tileWidth;
         this.tileHeight = parent.tileHeight;

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
@@ -5,6 +5,7 @@
 
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 
 /**
@@ -17,6 +18,11 @@ public class LevelSet {
      * The sector spanned by this level set.
      */
     public final Sector sector = new Sector();
+
+    /**
+     * Tile origin for this level set
+     */
+    public final Location tileOrigin = new Location();
 
     /**
      * The geographic width and height in degrees of tiles in the first level (lowest resolution) of this level set.
@@ -55,6 +61,7 @@ public class LevelSet {
      * Constructs a level set with specified parameters.
      *
      * @param sector          the sector spanned by this level set
+     * @param tileOrigin      the origin for this level set
      * @param firstLevelDelta the geographic width and height in degrees of tiles in the first level (lowest resolution)
      *                        of the level set
      * @param numLevels       the number of levels in the level set
@@ -67,10 +74,15 @@ public class LevelSet {
      *
      * @throws IllegalArgumentException If any argument is null, or if any dimension is zero
      */
-    public LevelSet(Sector sector, double firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
+    public LevelSet(Sector sector, Location tileOrigin, double firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
         if (sector == null) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingSector"));
+        }
+
+        if (tileOrigin == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingTileOrigin"));
         }
 
         if (firstLevelDelta <= 0) {
@@ -89,6 +101,7 @@ public class LevelSet {
         }
 
         this.sector.set(sector);
+        this.tileOrigin.set(tileOrigin);
         this.firstLevelDelta = firstLevelDelta;
         this.tileWidth = tileWidth;
         this.tileHeight = tileHeight;
@@ -116,6 +129,11 @@ public class LevelSet {
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingSector"));
         }
 
+        if (config.tileOrigin == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingTileOrigin"));
+        }
+
         if (config.firstLevelDelta <= 0) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "invalidTileDelta"));
@@ -132,6 +150,7 @@ public class LevelSet {
         }
 
         this.sector.set(config.sector);
+        this.tileOrigin.set(config.tileOrigin);
         this.firstLevelDelta = config.firstLevelDelta;
         this.tileWidth = config.tileWidth;
         this.tileHeight = config.tileHeight;
@@ -141,8 +160,7 @@ public class LevelSet {
 
     protected void assembleLevels() {
         for (int i = 0, len = this.levels.length; i < len; i++) {
-            double n = Math.pow(2, i);
-            double delta = firstLevelDelta / n;
+            double delta = firstLevelDelta / (1 << i);
             this.levels[i] = new Level(this, i, delta);
         }
     }

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
@@ -5,6 +5,7 @@
 
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 
 /**
@@ -17,6 +18,11 @@ public class LevelSetConfig {
      * The sector spanned by the level set.
      */
     public final Sector sector = new Sector().setFullSphere();
+
+    /**
+     * Tile origin for level set
+     */
+    public final Location tileOrigin = new Location(-90, -180);
 
     /**
      * The geographic width and height in degrees of tiles in the first level (lowest resolution) of the level set.

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.geom.BoundingBox;
 import gov.nasa.worldwind.geom.Frustum;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.render.RenderContext;
@@ -116,13 +117,14 @@ public class Tile {
      *
      * @param tileDelta the level's tile delta in degrees
      * @param latitude  the tile's minimum latitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return the computed row number
      */
-    public static int computeRow(double tileDelta, double latitude) {
-        int row = (int) Math.floor((latitude + 90) / tileDelta);
+    public static int computeRow(double tileDelta, double latitude, double origin) {
+        int row = (int) Math.floor((latitude - origin) / tileDelta);
 
-        if (latitude == 90) {
+        if (latitude - origin == 180) {
             row -= 1; // if latitude is at the end of the grid, subtract 1 from the computed row to return the last row
         }
 
@@ -134,13 +136,14 @@ public class Tile {
      *
      * @param tileDelta the level's tile delta in degrees
      * @param longitude the tile's minimum longitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return The computed column number
      */
-    public static int computeColumn(double tileDelta, double longitude) {
-        int col = (int) Math.floor((longitude + 180) / tileDelta);
+    public static int computeColumn(double tileDelta, double longitude, double origin) {
+        int col = (int) Math.floor((longitude - origin) / tileDelta);
 
-        if (longitude == 180) {
+        if (longitude - origin == 360) {
             col -= 1; // if longitude is at the end of the grid, subtract 1 from the computed column to return the last column
         }
 
@@ -152,13 +155,14 @@ public class Tile {
      *
      * @param tileDelta   the level's tile delta in degrees
      * @param maxLatitude the tile's maximum latitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return the computed row number
      */
-    public static int computeLastRow(double tileDelta, double maxLatitude) {
-        int row = (int) Math.ceil((maxLatitude + 90) / tileDelta - 1);
+    public static int computeLastRow(double tileDelta, double maxLatitude, double origin) {
+        int row = (int) Math.ceil((maxLatitude - origin) / tileDelta - 1);
 
-        if (maxLatitude + 90 < tileDelta) {
+        if (maxLatitude - origin < tileDelta) {
             row = 0; // if max latitude is in the first row, set the max row to 0
         }
 
@@ -170,13 +174,14 @@ public class Tile {
      *
      * @param tileDelta    the level's tile delta in degrees
      * @param maxLongitude the tile's maximum longitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return The computed column number
      */
-    public static int computeLastColumn(double tileDelta, double maxLongitude) {
-        int col = (int) Math.ceil((maxLongitude + 180) / tileDelta - 1);
+    public static int computeLastColumn(double tileDelta, double maxLongitude, double origin) {
+        int col = (int) Math.ceil((maxLongitude - origin) / tileDelta - 1);
 
-        if (maxLongitude + 180 < tileDelta) {
+        if (maxLongitude - origin < tileDelta) {
             col = 0; // if max longitude is in the first column, set the max column to 0
         }
 
@@ -211,15 +216,16 @@ public class Tile {
         }
 
         Sector sector = level.parent.sector;
+        Location tileOrigin = level.parent.tileOrigin;
         double tileDelta = level.tileDelta;
 
-        int firstRow = Tile.computeRow(tileDelta, sector.minLatitude());
-        int lastRow = Tile.computeLastRow(tileDelta, sector.maxLatitude());
-        int firstCol = Tile.computeColumn(tileDelta, sector.minLongitude());
-        int lastCol = Tile.computeLastColumn(tileDelta, sector.maxLongitude());
+        int firstRow = Tile.computeRow(tileDelta, sector.minLatitude(), tileOrigin.latitude);
+        int lastRow = Tile.computeLastRow(tileDelta, sector.maxLatitude(), tileOrigin.latitude);
+        int firstCol = Tile.computeColumn(tileDelta, sector.minLongitude(), tileOrigin.longitude);
+        int lastCol = Tile.computeLastColumn(tileDelta, sector.maxLongitude(), tileOrigin.longitude);
 
-        double firstRowLat = -90 + firstRow * tileDelta;
-        double firstRowLon = -180 + firstCol * tileDelta;
+        double firstRowLat = tileOrigin.latitude + firstRow * tileDelta;
+        double firstRowLon = tileOrigin.longitude + firstCol * tileDelta;
         double lat = firstRowLat;
         double lon;
 

--- a/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
@@ -14,6 +14,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.util.LevelSet;
@@ -81,7 +82,7 @@ public class BasicTerrainTest {
         this.terrain = new BasicTerrain();
 
         // Add a terrain tile used to the mocked terrain
-        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), 1.0, 1, 5, 5); // tiles with 5x5 vertices
+        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 1.0, 1, 5, 5); // tiles with 5x5 vertices
         TerrainTile tile = new TerrainTile(new Sector(0, 0, 1, 1), levelSet.firstLevel(), 90, 180);
         ((BasicTerrain) this.terrain).addTile(tile);
 


### PR DESCRIPTION
### Description of the Change
Basic implementation of GeoPackage does not work properly:
1) It does not support tile matrix sets which count tiles from their local tile origin, not from full sphere origin (-90, -180).
2) It calculates wrong GeoPackage row in case tile matrix has height not equals current WWD level height, which is always equals some power of two. 
3) It does not copy content identifier into renderable display name. 

That's why current PR adds following features:
1) Add tile origin attribute to level set.
2) Enhance tile row and column calculation routines with tile origin parameter.
3) Fix level width and height calculation in case of non-full sphere level set sector used.
4) Add support of local tile origin based on tile matrix set extent instead of full sphere origin.
5) Add surface image name based on content identifier.
6) Change level set sector initialization based on tile matrix set extent instead of content extent.
7) Change first level tile delta and number of levels calculation based on tile matrix zoom levels.
8) Fix row calculation in tile factory.

### Why Should This Be In Core?
GeoPackage is the only way to use offline maps in WorldWondAndroid for now, but it does not work properly and should be fixed.

### Benefits
Allows to prepare and use offline map GPKG files using some 3rd party software.
Works with any GPKG files which comply GeoPackage specification, not only tutorial one.

### Potential Drawbacks
Tile origin initialization was added to many dependent places due to current LevelSet initialization architecture.

### Applicable Issues